### PR TITLE
correctly pop call frame in all OP_RETURN paths, and restore it when …

### DIFF
--- a/cyarg/routine.c
+++ b/cyarg/routine.c
@@ -80,6 +80,7 @@ ObjRoutine* newRoutine() {
 void runAndRenter(ObjRoutine* routine) {
     run(routine);
     pop(routine);
+    pushEntryElements(routine);
     enterEntryFunction(routine);
 }
 
@@ -158,9 +159,7 @@ void yieldFromRoutine(ObjRoutine* context) {
 
 void returnFromRoutine(ObjRoutine* context, Value result) {
     assert(context->frameCount == 0);
-    pop(context);
     context->result = result;
-    push(context, result);
     context->state = EXEC_CLOSED;
 }
 

--- a/cyarg/vm.c
+++ b/cyarg/vm.c
@@ -1118,15 +1118,16 @@ InterpretResult run(ObjRoutine* routine) {
             }
             case OP_RETURN: {
                 Value result = pop(routine);
+                tempRootPush(result);
                 closeUpvalues(routine, frame->stackEntryIndex);
                 routine->frameCount--;
+                popFrame(routine, frame);
+                push(routine, result);
+                tempRootPop();
                 if (routine->frameCount == 0) {
                     returnFromRoutine(routine, result);
                     return INTERPRET_OK;
                 }
-                
-                popFrame(routine, frame);
-                push(routine, result);
                 frame = &routine->frames[routine->frameCount - 1];
                 break;
             }


### PR DESCRIPTION
…re-entering. Keep returned results under memory/gc accounting.