### PR TITLE
Three tests to capture prior regressions in interrupt handling

### DIFF
--- a/yarg/test/interrupts/closure_frame_interrupt.ya
+++ b/yarg/test/interrupts/closure_frame_interrupt.ya
@@ -1,0 +1,39 @@
+
+fun setup_interrupt(number) {
+    var count = 0;
+
+    fun handler() {
+        fun display_count(count) {
+            print count;
+        }
+
+        print "handler";
+        print number;
+        count = count + 1;
+        display_count(count);
+    }
+
+    var handler_routine = make_routine(handler, true);
+    var handler_address = pin(handler_routine);
+    irq_add_shared_handler(number, handler_address, 1);
+
+    return handler_address;
+}
+
+var handler_address1 = setup_interrupt(1);
+
+test_interrupt(1);
+print test_sync();  // expect: Waiting for interrupts to be simulated - handler
+// expect: 1
+// expect: 1
+// expect: done
+// expect: Type:any[]:[]
+
+test_interrupt(1);
+print test_sync();  // expect: Waiting for interrupts to be simulated - handler
+// expect: 1
+// expect: 2
+// expect: done
+// expect: Type:any[]:[]
+
+irq_remove_handler(1, handler_address1);

--- a/yarg/test/interrupts/repeating_interrupt.ya
+++ b/yarg/test/interrupts/repeating_interrupt.ya
@@ -1,0 +1,25 @@
+var count = 0;
+
+fun handler() {
+    print "handler";
+    count = count + 1;
+    print count;
+}
+
+var handler_routine = make_routine(handler, true);
+var handler_address = pin(handler_routine);
+irq_add_shared_handler(1, handler_address, 1);
+
+test_interrupt(1);
+print test_sync();  // expect: Waiting for interrupts to be simulated - handler
+// expect: 1
+// expect: done
+// expect: Type:any[]:[]
+
+test_interrupt(1);
+print test_sync();  // expect: Waiting for interrupts to be simulated - handler
+// expect: 2
+// expect: done
+// expect: Type:any[]:[]
+
+irq_remove_handler(1, handler_address1);

--- a/yarg/test/interrupts/single_interrupt.ya
+++ b/yarg/test/interrupts/single_interrupt.ya
@@ -1,0 +1,14 @@
+fun handler() {
+    print "handler";
+}
+
+var handler_routine = make_routine(handler, true);
+var handler_address = pin(handler_routine);
+irq_add_shared_handler(1, handler_address, 1);
+
+test_interrupt(1);
+print test_sync();  // expect: Waiting for interrupts to be simulated - handler
+// expect: done
+// expect: Type:any[]:[]
+
+irq_remove_handler(1, handler_address);


### PR DESCRIPTION
Captures three prior regressions:

 - Interrupts breaking entirely
 - Repeated calls to same interrupt handler not cleanly handled
 - Calls to handlers with more complex call frames (closures) not correctly handled.