### PR TITLE
bug: removeLastFromDynamicObjArray single element

### DIFF
--- a/cyarg/object.c
+++ b/cyarg/object.c
@@ -60,7 +60,7 @@ void appendToDynamicObjArray(DynamicObjArray* array, Obj* obj) {
 
 Obj* removeLastFromDynamicObjArray(DynamicObjArray* array) {
     Obj* end = NULL;
-    if (array->objectCount > 1) {
+    if (array->objectCount > 0) {
         end = array->objects[array->objectCount - 1];
         array->objectCount--;
     }


### PR DESCRIPTION
Addresses #111 , accounting more conventionally for the first element in an array.