### PR TITLE
exec() does not accept nil

### DIFF
--- a/yarg/specimen/repl.ya
+++ b/yarg/specimen/repl.ya
@@ -2,7 +2,7 @@ fun line_repl() {
     c_stdout_puts("yarg> ");
     while (true) {
         var line = c_stdin_gets();
-        if (line != "") {
+        if (line != nil and line != "") {
             exec(line);
             c_stdout_puts("yarg> ");
         }


### PR DESCRIPTION
 - generated by xcode during c_stdin_gets when adding a breakpoint
 - Adds trading newline, because Xcode.