### PR TITLE
Yarg console from hostyarg

### DIFF
--- a/hostyarg/cmd/yarg/yarg.go
+++ b/hostyarg/cmd/yarg/yarg.go
@@ -16,12 +16,13 @@ import (
 )
 
 func exitWithUsageError(usagenote string) {
-	fmt.Println(usagenote)
+	fmt.Fprintln(os.Stderr, usagenote)
+	fmt.Fprintln(os.Stderr, "Use 'yarg help' for more information.")
 	os.Exit(int(sysexit.ErrUsage))
 }
 
 func exitWithError(errnote string) {
-	fmt.Println(errnote)
+	fmt.Fprintln(os.Stderr, errnote)
 	os.Exit(1)
 }
 
@@ -33,6 +34,29 @@ func dispatchSubCommand(args []string) {
 
 	flags := flag.NewFlagSet(args[0], flag.ExitOnError)
 	switch args[0] {
+	case "help":
+		fmt.Println("yarg is a tool for working with Yarg sources, device images and devices running Yarg.")
+		fmt.Println("Usage: yarg [-v] <command> [options]")
+		fmt.Println("Commands:")
+		fmt.Println("  help - show this help message")
+		fmt.Println("  runtests - run tests on the host")
+		fmt.Println("  format - format a device image with a littlefs filesystem")
+		fmt.Println("  ls - list contents of a directory in a littlefs filesystem")
+		fmt.Println("  fsinfo - print information about a littlefs filesystem")
+		fmt.Println("  cp - copy a file to or from a littlefs filesystem")
+		fmt.Println("  mkdir - create a directory in a littlefs filesystem")
+		fmt.Println("  devices - list connected devices")
+		fmt.Println("  resetdevice - reset the connected device")
+		fmt.Println("  flashdevice - flash a binary to the connected device")
+		fmt.Println("  compile - compile a Yarg source file, reporting errors if any")
+		fmt.Println("  run - run a Yarg source file on the connected device")
+		fmt.Println("  repl - start a REPL connected to the device")
+		fmt.Println("  test - run tests on the connected device")
+		fmt.Println("device commands can specify:")
+		fmt.Println("  a connected device (which is the default if found) with: --port")
+		fmt.Println("  or a host based yarg system with:")
+		fmt.Println("     --interpreter path/to/cyarg --lib path/to/libraries")
+		os.Exit(0)
 	case "format":
 		formatFSFS := flags.String("image", "", "image containing filesystem to format")
 		formatCreate := flags.Bool("create", false, "create image if it doesn't exist")

--- a/hostyarg/cmd/yarg/yarg.go
+++ b/hostyarg/cmd/yarg/yarg.go
@@ -161,7 +161,21 @@ func dispatchSubCommand(args []string) {
 		if err != nil {
 			exitWithError(err.Error())
 		}
+	case "repl":
+		devicePort := flags.String("port", "", "serial port to use as device console")
+		localRunInterpreter := flags.String("interpreter", "", "default interpreter")
+		localLib := flags.String("lib", "", "library to include")
+		flags.Parse(args[1:])
 
+		runner, err := hostyarg.DefaultYargRunner(*devicePort, *localRunInterpreter, *localLib)
+		if err != nil {
+			exitWithError(err.Error())
+		}
+
+		err = runner.REPL()
+		if err != nil {
+			exitWithError(err.Error())
+		}
 	case "test":
 		testRunInterpreter := flags.String("interpreter", "cyarg", "default interpreter")
 		testRunSource := flags.String("source", "", "source of test to run")

--- a/hostyarg/cmd/yarg/yarg.go
+++ b/hostyarg/cmd/yarg/yarg.go
@@ -190,8 +190,10 @@ func dispatchSubCommand(args []string) {
 			os.Exit(1)
 		}
 	case "devices":
+		deviceInterpreter := flags.String("interpreter", "", "default interpreter")
+		deviceLib := flags.String("lib", "", "library to include in test runs")
 		flags.Parse(args[1:])
-		hostyarg.CmdListDevices()
+		hostyarg.CmdListDevices(*deviceInterpreter, *deviceLib)
 	default:
 		exitWithUsageError("unknown command")
 	}

--- a/hostyarg/hostyarg.go
+++ b/hostyarg/hostyarg.go
@@ -26,6 +26,7 @@ func DevicePath(path string) string {
 
 type YargRunner interface {
 	Run(source string) error
+	REPL() error
 }
 
 type DeviceRunner struct {
@@ -57,6 +58,10 @@ func (d *DeviceRunner) Run(source string) error {
 	return error
 }
 
+func (d *DeviceRunner) REPL() error {
+	return fmt.Errorf("REPL not implemented for device runner")
+}
+
 type HostRunner struct {
 	Interpreter string
 	LibPath     string
@@ -81,6 +86,10 @@ func (h *HostRunner) Run(source string) error {
 		}
 	}
 	return nil
+}
+
+func (h *HostRunner) REPL() error {
+	return fmt.Errorf("REPL not implemented for host runner")
 }
 
 func DefaultYargRunner(suppliedPort, suppliedInterpreter, suppliedLib string) (runner YargRunner, err error) {

--- a/hostyarg/hostyarg.go
+++ b/hostyarg/hostyarg.go
@@ -3,7 +3,6 @@ package hostyarg
 import (
 	"fmt"
 	"io/fs"
-	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -123,31 +122,46 @@ func DefaultYargRunner(suppliedPort, suppliedInterpreter, suppliedLib string) (r
 	return nil, fmt.Errorf("invalid configuration")
 }
 
-func CmdListDevices() bool {
+func CmdListDevices(interpreter, lib string) bool {
+
+	if interpreter != "" && lib != "" {
+		if _, err := os.Stat(interpreter); err != nil {
+			fmt.Fprintln(os.Stderr, "could not stat interpreter at "+interpreter)
+			return false
+		}
+		if _, err := os.Stat(lib); err != nil {
+			fmt.Fprintln(os.Stderr, "could not stat library at "+lib)
+			return false
+		}
+		fmt.Printf("Host device interpreter %s and library %s\n", interpreter, lib)
+	} else if interpreter != "" || lib != "" {
+		fmt.Fprintln(os.Stderr, "cannot specify only one of interpreter and lib for devices command")
+		return false
+	}
 
 	detailedports, err := enumerator.GetDetailedPortsList()
 	if err != nil {
-		log.Println(err)
+		fmt.Fprintln(os.Stderr, err)
 		return false
 	}
 	if len(detailedports) == 0 {
-		log.Println("No device serial ports found!")
+		fmt.Fprintln(os.Stderr, "No device serial ports found!")
 		return false
 	}
 	for _, port := range detailedports {
 		if port.IsUSB && port.VID == devicerunner.RaspberryPiVID {
 			switch port.PID {
 			case devicerunner.DebugProbePID:
-				fmt.Printf("%s, Serial=%s, VID:PID=%s:%s (Debug Probe)\n", port.Name, port.SerialNumber, port.VID, port.PID)
+				fmt.Printf("Connected Debug Probe %s, Serial=%s, VID:PID=%s:%s\n", port.Name, port.SerialNumber, port.VID, port.PID)
 			case devicerunner.PicoPID:
-				fmt.Printf("%s, Serial=%s, VID:PID=%s:%s (Pico)\n", port.Name, port.SerialNumber, port.VID, port.PID)
+				fmt.Printf("Connected Pico %s, Serial=%s, VID:PID=%s:%s\n", port.Name, port.SerialNumber, port.VID, port.PID)
 			default:
-				fmt.Printf("%s, Serial=%s, VID:PID=%s:%s (Raspberry Pi Device)\n", port.Name, port.SerialNumber, port.VID, port.PID)
+				fmt.Printf("Connected Raspberry Pi Device %s, Serial=%s, VID:PID=%s:%s\n", port.Name, port.SerialNumber, port.VID, port.PID)
 			}
 		} else if port.IsUSB {
-			log.Printf("%s, VID:PID=%s:%s\n", port.Name, port.VID, port.PID)
+			fmt.Printf("Connected USB Serial %s, VID:PID=%s:%s\n", port.Name, port.VID, port.PID)
 		} else {
-			log.Printf("%s\n", port.Name)
+			fmt.Printf("Connected Serial%s\n", port.Name)
 		}
 	}
 	return true

--- a/hostyarg/hostyarg.go
+++ b/hostyarg/hostyarg.go
@@ -59,7 +59,7 @@ func (d *DeviceRunner) Run(source string) error {
 }
 
 func (d *DeviceRunner) REPL() error {
-	return fmt.Errorf("REPL not implemented for device runner")
+	return devicerunner.StreamSerialIO(d.Port.Name())
 }
 
 type HostRunner struct {
@@ -89,7 +89,13 @@ func (h *HostRunner) Run(source string) error {
 }
 
 func (h *HostRunner) REPL() error {
-	return fmt.Errorf("REPL not implemented for host runner")
+	runner := exec.Command(h.Interpreter, "--lib", h.LibPath)
+
+	runner.Stdin = os.Stdin
+	runner.Stdout = os.Stdout
+	runner.Stderr = os.Stderr
+
+	return runner.Run()
 }
 
 func DefaultYargRunner(suppliedPort, suppliedInterpreter, suppliedLib string) (runner YargRunner, err error) {

--- a/hostyarg/internal/devicerunner/devicerunner.go
+++ b/hostyarg/internal/devicerunner/devicerunner.go
@@ -6,9 +6,12 @@ package devicerunner
 
 import (
 	"fmt"
+	"io"
 	"log"
+	"os"
 	"os/exec"
 	"strings"
+	"sync"
 
 	"github.com/yarg-lang/yarg-lang/hostyarg/internal/runbinary"
 
@@ -127,6 +130,68 @@ func GetSerialOutput(portName string, sourcePath string, done chan error) (outpu
 		}
 	}
 	return output
+}
+
+func StreamSerialIO(portName string) error {
+	serial, err := serial.Open(portName, &serial.Mode{BaudRate: 115200})
+	if err != nil {
+		log.Println("Failed to open serial port:", err)
+		return err
+	}
+	defer serial.Close()
+
+	fmt.Fprint(serial, "\r\n")
+
+	input_error := make(chan error)
+
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		defer wg.Done()
+		buff := make([]byte, 1)
+		for {
+			n, err := os.Stdin.Read(buff)
+			if err != nil {
+				input_error <- err
+				return
+			}
+			if buff[:n][0] == '\n' {
+				fmt.Fprint(serial, "\r\n")
+				continue
+			}
+			serial.Write(buff[:n])
+		}
+	})
+
+	output_error := make(chan error)
+
+	wg.Go(func() {
+		defer wg.Done()
+
+		buff := make([]byte, 1)
+		for {
+			n, err := serial.Read(buff)
+			if err == io.EOF {
+				output_error <- nil
+				return
+			}
+			if err != nil {
+				output_error <- err
+				return
+			}
+			fmt.Print(string(buff[:n]))
+		}
+	})
+
+	wg.Wait()
+	ine := <-input_error
+	oute := <-output_error
+	if ine != nil {
+		return ine
+	} else if oute != nil {
+		return oute
+	} else {
+		return nil
+	}
 }
 
 func DefaultPort() (p PicoPort, ok bool) {

--- a/hostyarg/internal/hostrunner/hostrunner.go
+++ b/hostyarg/internal/hostrunner/hostrunner.go
@@ -74,18 +74,3 @@ func compileFile(interpreter string, source string, logname string) {
 		}
 	}
 }
-
-func CmdRunLocally(source string, interpreter string) error {
-	runner := exec.Command(interpreter, source)
-
-	output, errors, _, ok := runbinary.RunCommand(runner)
-	if ok {
-		for _, line := range output {
-			fmt.Println(line)
-		}
-		for _, line := range errors {
-			fmt.Println(line)
-		}
-	}
-	return nil
-}


### PR DESCRIPTION
Provides 'yarg repl' as a command, which will connect to either a device available via some serial connection, or to a specified host implementation of cyarg

Also provides yarg help and associated tidy up.