### PR TITLE
A test to demonstrate the full language is available in interrupts

### DIFF
--- a/test/hardware/README.md
+++ b/test/hardware/README.md
@@ -9,6 +9,7 @@ cheese.ya
 scone.ya
 ../../yarg/specimen/hello_led.ya
 ../../yarg/specimen/hello_button.ya
+interrupt.ya
 alarm.ya
 blinky.ya
 coroutine-flash.ya

--- a/test/hardware/interrupt.ya
+++ b/test/hardware/interrupt.ya
@@ -1,0 +1,30 @@
+// start a recurring timer, and have it do work at the same time as the script.
+// should run cleanly to completion, without corrption present on the output.
+import("timer");
+
+fun maths(iterations, name) {
+    var a = new(int[1]);
+    for (var i = 0; i < iterations; i = i + 1)
+    {
+        print name + " maths: " + string(a[0]);
+        a[0] = a[0] + 1;
+    }
+    print name + " maths computed: " + string(a[0]);
+}
+
+fun start_interrupt1()
+{
+    fun interrupt_maths()
+    {
+        maths(5, "interrupt");
+    }
+    repeating_alarm_ms(0, 50, interrupt_maths);
+    return uint32(0);
+}
+maths(10, "pre-interrupt");
+
+var alarm = start_interrupt1();
+
+maths(1000, "interruptible");
+
+cancel_repeating_alarm(alarm);

--- a/tools/build-test-hardware.sh
+++ b/tools/build-test-hardware.sh
@@ -11,14 +11,15 @@ then
 fi
 
 cp ../../build/yarg-lang.uf2 $TARGETUF2
-$HOSTYARG cp -fs $TARGETUF2 -src cheese.ya -dest cheese.ya
-$HOSTYARG cp -fs $TARGETUF2 -src scone.ya -dest scone.ya
-$HOSTYARG cp -fs $TARGETUF2 -src alarm.ya -dest alarm.ya
-$HOSTYARG cp -fs $TARGETUF2 -src blinky.ya -dest blinky.ya
-$HOSTYARG cp -fs $TARGETUF2 -src main.ya -dest main.ya
-$HOSTYARG cp -fs $TARGETUF2 -src coroutine-flash.ya -dest coroutine-flash.ya
-$HOSTYARG cp -fs $TARGETUF2 -src multicore-flash.ya -dest multicore-flash.ya
-$HOSTYARG cp -fs $TARGETUF2 -src timed-flash.ya -dest timed-flash.ya
+for test in cheese.ya scone.ya interrupt.ya alarm.ya blinky.ya main.ya coroutine-flash.ya multicore-flash.ya timed-flash.ya
+do
+    $HOSTYARG compile --interpreter ../../bin/cyarg --source $test
+    $HOSTYARG cp -fs $TARGETUF2 -src $test -dest $test
+done
+
+$HOSTYARG compile --interpreter ../../bin/cyarg --source ../../yarg/specimen/hello_led.ya
 $HOSTYARG cp -fs $TARGETUF2 -src ../../yarg/specimen/hello_led.ya -dest hello_led.ya
+
+$HOSTYARG compile --interpreter ../../bin/cyarg --source ../../yarg/specimen/hello_button.ya
 $HOSTYARG cp -fs $TARGETUF2 -src ../../yarg/specimen/hello_button.ya -dest hello_button.ya
 popd > /dev/null


### PR DESCRIPTION
Adds test/hardware/interrupt.ya to exercise a repeating interruption of the script.

Currently known to fail.