### PR TITLE
wrap 'malloc()' and gc in a critical_section on pico

### DIFF
--- a/cyarg/memory.c
+++ b/cyarg/memory.c
@@ -16,8 +16,20 @@
 
 #define GC_HEAP_GROW_FACTOR 2
 
+// can only be called during gc, so the heap critical section is already held.
+void* gc_free(void* pointer, size_t oldSize, size_t newSize) {
+    if (newSize != 0) {
+        PRINTERR("help! bad free.\n");
+        exit(1);
+    }
+    vm.bytesAllocated += newSize - oldSize;
+
+    free(pointer);
+    return NULL;
+}
+
 void* reallocate(void* pointer, size_t oldSize, size_t newSize) {
-    platform_mutex_enter(&vm.heap);
+    platform_critical_section_enter_blocking(&vm.heap);
 
     vm.bytesAllocated += newSize - oldSize;
     if (newSize > oldSize) {
@@ -30,10 +42,9 @@ void* reallocate(void* pointer, size_t oldSize, size_t newSize) {
         }
     }
 
-    platform_mutex_leave(&vm.heap);
-
     if (newSize == 0) {
         free(pointer);
+        platform_critical_section_exit(&vm.heap);
         return NULL;
     }
 
@@ -42,12 +53,13 @@ void* reallocate(void* pointer, size_t oldSize, size_t newSize) {
         PRINTERR("help! no memory.");
         exit(1);
     }
+    platform_critical_section_exit(&vm.heap);
     return result;
 }
 
 void tempRootPush(Value value) {
 
-    platform_mutex_enter(&vm.heap);
+    platform_critical_section_enter_blocking(&vm.heap);
 
     *vm.tempRootsTop = value;
     vm.tempRootsTop++;
@@ -56,14 +68,14 @@ void tempRootPush(Value value) {
         fatalVMError("Allocation Stash Max Exeeded.");
     }
 
-    platform_mutex_leave(&vm.heap);
+    platform_critical_section_exit(&vm.heap);
 }
 
 Value tempRootPop() {
-    platform_mutex_enter(&vm.heap);
+    platform_critical_section_enter_blocking(&vm.heap);
     vm.tempRootsTop--;
     Value result = *vm.tempRootsTop;
-    platform_mutex_leave(&vm.heap);
+    platform_critical_section_exit(&vm.heap);
     return result;
 }
 
@@ -492,7 +504,7 @@ static void freeObject(Obj* object) {
         case OBJ_PACKEDPOINTER: {
             ObjPackedPointer* ptr = (ObjPackedPointer*) object;
             Value targetType = ptr->type->target_type == NULL ? NIL_VAL : OBJ_VAL(ptr->type->target_type);
-            ptr->destination = reallocate(ptr->destination, yt_sizeof_type_storage(targetType), 0);
+            ptr->destination = gc_free(ptr->destination, yt_sizeof_type_storage(targetType), 0);
             FREE(ObjPackedPointer, object); 
             break;
         }
@@ -501,14 +513,14 @@ static void freeObject(Obj* object) {
             ObjPackedUniformArray* array = (ObjPackedUniformArray*)object;
             ObjConcreteYargTypeArray* arrayType = (ObjConcreteYargTypeArray*)array->store.storedType;
             size_t element_size = arrayElementSize(arrayType);
-            array->store.storedValue = reallocate(array->store.storedValue, arrayType->cardinality * element_size, 0);
+            array->store.storedValue = gc_free(array->store.storedValue, arrayType->cardinality * element_size, 0);
             FREE(ObjPackedUniformArray, object);
             break;
         }
         case OBJ_UNOWNED_PACKEDSTRUCT: FREE(ObjPackedStruct, object); break;
         case OBJ_PACKEDSTRUCT: {
             ObjPackedStruct* struct_ = (ObjPackedStruct*) object;
-            struct_->store.storedValue = reallocate(struct_->store.storedValue, ((ObjConcreteYargTypeStruct*)(struct_->store.storedType))->storage_size, 0);
+            struct_->store.storedValue = gc_free(struct_->store.storedValue, ((ObjConcreteYargTypeStruct*)(struct_->store.storedType))->storage_size, 0);
             FREE(ObjPackedStruct, object);
             break;            
         }
@@ -635,8 +647,6 @@ static void sweep() {
 
 void collectGarbage() {
 
-    platform_mutex_enter(&vm.heap);
-
 #ifdef DEBUG_LOG_GC
     PRINTERR("-- gc begin\n");
     size_t before = vm.bytesAllocated;
@@ -657,7 +667,6 @@ void collectGarbage() {
              vm.nextGC);
 #endif
 
-    platform_mutex_leave(&vm.heap);
 }
 
 void freeObjects() {

--- a/cyarg/memory.h
+++ b/cyarg/memory.h
@@ -11,7 +11,7 @@
 #define ALLOCATE(type, count) \
     (type*)reallocate(NULL, 0, sizeof(type) * (count))
 
-#define FREE(type, pointer) reallocate(pointer, sizeof(type), 0)
+#define FREE(type, pointer) gc_free(pointer, sizeof(type), 0)
 
 #define GROW_CAPACITY(capacity) \
     ((capacity) < 8 ? 8 : (capacity) * 2)
@@ -21,8 +21,9 @@
         sizeof(type) * (newCount))
 
 #define FREE_ARRAY(type, pointer, oldCount) \
-    reallocate(pointer, sizeof(type) * oldCount, 0)
+    gc_free(pointer, sizeof(type) * oldCount, 0)
 
+void* gc_free(void* pointer, size_t oldSize, size_t newSize);
 void* reallocate(void* pointer, size_t oldSize, size_t newSize);
 
 void tempRootPush(Value value);

--- a/cyarg/object.c
+++ b/cyarg/object.c
@@ -21,12 +21,12 @@ Obj* allocateObject(size_t size, ObjType type) {
     object->type = type;
     object->isMarked = false;
 
-    platform_mutex_enter(&vm.heap);
+    platform_critical_section_enter_blocking(&vm.heap);
 
     object->next = vm.objects;
     vm.objects = object;
     
-    platform_mutex_leave(&vm.heap);
+    platform_critical_section_exit(&vm.heap);
 
 #ifdef DEBUG_LOG_GC
     PRINTERR("%p allocate %zu for %d\n", (void*)object, size, type);

--- a/cyarg/vm.c
+++ b/cyarg/vm.c
@@ -136,8 +136,8 @@ void initVMMemory() {
 
     vm.nextGC = FIRST_GC_AT;
 
-    platform_mutex_init(&vm.heap);
-    platform_mutex_init(&vm.env);
+    platform_critical_section_init(&vm.heap);
+    platform_critical_section_init(&vm.env);
 }
 
 void initVMRuntime() {
@@ -802,28 +802,28 @@ InterpretResult run(ObjRoutine* routine) {
                 break;
             }
             case OP_GET_GLOBAL: {
-                platform_mutex_enter(&vm.env);
+                platform_critical_section_enter_blocking(&vm.env);
                 ObjString* name = READ_STRING();
                 ValueCell cell;
                 if (!tableCellGet(&vm.globals, name, &cell)) {
                     runtimeError(routine, "Undefined variable (OP_GET_GLOBAL) '%s'.", name->chars);
-                    platform_mutex_leave(&vm.env);
+                    platform_critical_section_exit(&vm.env);
                     return INTERPRET_RUNTIME_ERROR;
                 }
                 push(routine, cell.value);
-                platform_mutex_leave(&vm.env);
+                platform_critical_section_exit(&vm.env);
                 break;
             }
             case OP_DEFINE_GLOBAL: {
-                platform_mutex_enter(&vm.env);
+                platform_critical_section_enter_blocking(&vm.env);
                 ObjString* name = READ_STRING();
                 tableCellSet(&vm.globals, name, *peekCell(routine, 0));
                 pop(routine);
-                platform_mutex_leave(&vm.env);
+                platform_critical_section_exit(&vm.env);
                 break;
             }
             case OP_SET_GLOBAL: {
-                platform_mutex_enter(&vm.env);
+                platform_critical_section_enter_blocking(&vm.env);
                 ObjString* name = READ_STRING();
                 ValueCell* lhs = NULL;
                 if (tableCellGetPlace(&vm.globals, name, &lhs)) {
@@ -832,15 +832,15 @@ InterpretResult run(ObjRoutine* routine) {
 
                     if (!assignToValueCellTarget(lhsTrg, rhs->value)) {
                         runtimeError(routine, "Cannot set global variable to incompatible type.");
-                        platform_mutex_leave(&vm.env);
+                        platform_critical_section_exit(&vm.env);
                         return INTERPRET_RUNTIME_ERROR;
                     }
                 } else {
                     runtimeError(routine, "Undefined variable (OP_SET_GLOBAL) '%s'.", name->chars);
-                    platform_mutex_leave(&vm.env);
+                    platform_critical_section_exit(&vm.env);
                     return INTERPRET_RUNTIME_ERROR;
                 }
-                platform_mutex_leave(&vm.env);
+                platform_critical_section_exit(&vm.env);
                 break;
             }
             case OP_INITIALISE: {

--- a/cyarg/vm.h
+++ b/cyarg/vm.h
@@ -22,14 +22,14 @@ typedef struct {
     ObjRoutine* pinnedRoutines[MAX_PINNED_ROUTINES];
     PinnedRoutineHandler pinnedRoutineHandlers[MAX_PINNED_ROUTINES];
     
-    platform_mutex env;
+    platform_critical_section env;
     
     ValueCellTable globals;
     ValueTable strings;
     ObjString* initString;
     ObjString* libraryPath;
 
-    platform_mutex heap;
+    platform_critical_section heap;
 
     Value tempRoots[TEMP_ROOTS_MAX];
     Value* tempRootsTop;

--- a/test/benchmark/stable-interrupt.ya
+++ b/test/benchmark/stable-interrupt.ya
@@ -1,0 +1,68 @@
+import("timer");
+
+var uint32 max_samples = 500;
+var uint64[500] samples;
+var uint32 samples_taken = 0;
+
+fun work(j) {
+    // do some work
+    var x = new(int[100]);
+    x[0] = j;
+    x[0] = x[0] * 2;
+    var y = new(int[100]);
+    y[0] = x[0] + 1;
+}
+
+fun repeating_tick(alarm, repeat_us) {
+
+    fun next_target() {
+        var uint64 t = get_time_latched() + uint64(repeat_us);
+        return uint32(t & uint64(0xFFFFFFFF));
+    }
+
+    fun alarm_irq_respsonse() {
+        poke timer.intr, REG_ALIAS_CLR_BITS, uint32(0x1) << alarm;
+
+        if (samples_taken < max_samples) {
+            samples[samples_taken] = get_time_latched();
+            samples_taken = samples_taken + uint32(1);
+        }
+
+        poke timer.alarm[alarm], next_target();
+    }
+
+    poke timer.inte, REG_ALIAS_SET_BITS, uint32(0x1) << alarm;
+
+    enable_alarm_handler(alarm, alarm_irq_respsonse);
+
+    poke timer.alarm[alarm], next_target();
+}
+
+var tick_ms = 500;
+var job_iterations = 2000;
+
+print "Starting benchmark with tick interval: " + string(tick_ms) + " ms and job iterations: " + string(job_iterations);
+
+repeating_tick(0, tick_ms);
+
+// do some stuff while the interrupts occur. This should not cause jitter in the interrupts.
+for (var j = 0; j < job_iterations; j = j + 1) {
+    work(j);
+}
+
+cancel_repeating_alarm(0);
+
+uint64 prev;
+uint64 max_diff = 0;
+for (var i = 0; i < (int(samples_taken) - 1); i = i + 1) {
+    if (i > 0) {
+        uint64 diff = samples[i] - prev;
+        if (diff > max_diff) {
+            max_diff = diff;
+        }
+        print("Interrupt at: " + string(samples[i]) + " us, difference: " + string(diff) + " us");
+    }
+    prev = samples[i];
+}
+print "Total samples taken: " + string(samples_taken);
+print "Maximum difference: " + string(max_diff) + " us";

--- a/test/hardware/blinky.ya
+++ b/test/hardware/blinky.ya
@@ -4,7 +4,7 @@ import("timer");
 gpio_init(pico_led);
 gpio_set_direction(pico_led, GPIO_OUT);
 
-var n = 6;
+var n = 4;
 
 while (n > 0) {
     gpio_put(pico_led, !gpio_get(pico_led));

--- a/test/test-benchmark.sh
+++ b/test/test-benchmark.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+# omitted, only runs on pico: stable-interrupt
 BENCHMARKS="fib equality string_equality instantiation invocation \
                 method_call properties trees zoo zoo_batch binary_trees int-perform"
 

--- a/test/yarg-expect/rp2040-pico/m0plus.ya
+++ b/test/yarg-expect/rp2040-pico/m0plus.ya
@@ -1,0 +1,32 @@
+import("m0plus");
+
+print m0plus.syst_csr;    // expect: <*Type:uint32:0xe000e010>
+print m0plus.syst_rvr;    // expect: <*Type:uint32:0xe000e014>
+print m0plus.syst_cvr;    // expect: <*Type:uint32:0xe000e018>
+print m0plus.syst_calib;  // expect: <*Type:uint32:0xe000e01c>
+print m0plus.nvic_iser;   // expect: <*Type:uint32:0xe000e100>
+print m0plus.nvic_icer;   // expect: <*Type:uint32:0xe000e180>
+print m0plus.nvic_ispr;   // expect: <*Type:uint32:0xe000e200>
+print m0plus.nvic_icpr;   // expect: <*Type:uint32:0xe000e280>
+print m0plus.nvic_ipr[0]; // expect: <*Type:uint32:0xe000e400>
+print m0plus.nvic_ipr[1]; // expect: <*Type:uint32:0xe000e404>
+print m0plus.nvic_ipr[2]; // expect: <*Type:uint32:0xe000e408>
+print m0plus.nvic_ipr[3]; // expect: <*Type:uint32:0xe000e40c>
+print m0plus.nvic_ipr[4]; // expect: <*Type:uint32:0xe000e410>
+print m0plus.nvic_ipr[5]; // expect: <*Type:uint32:0xe000e414>
+print m0plus.nvic_ipr[6]; // expect: <*Type:uint32:0xe000e418>
+print m0plus.nvic_ipr[7]; // expect: <*Type:uint32:0xe000e41c>
+print m0plus.cpuid;       // expect: <*Type:uint32:0xe000ed00>
+print m0plus.icsr;        // expect: <*Type:uint32:0xe000ed04>
+print m0plus.vtor;        // expect: <*Type:uint32:0xe000ed08>
+print m0plus.aircr;       // expect: <*Type:uint32:0xe000ed0c>
+print m0plus.scr;         // expect: <*Type:uint32:0xe000ed10>
+print m0plus.ccr;         // expect: <*Type:uint32:0xe000ed14>
+print m0plus.shpr2;       // expect: <*Type:uint32:0xe000ed1c>
+print m0plus.shpr3;       // expect: <*Type:uint32:0xe000ed20>
+print m0plus.shcsr;       // expect: <*Type:uint32:0xe000ed24>
+print m0plus.mpu_type;    // expect: <*Type:uint32:0xe000ed90>
+print m0plus.mpu_ctrl;    // expect: <*Type:uint32:0xe000ed94>
+print m0plus.mpu_rnr;     // expect: <*Type:uint32:0xe000ed98>
+print m0plus.mpu_rbar;    // expect: <*Type:uint32:0xe000ed9c>
+print m0plus.mpu_rasr;    // expect: <*Type:uint32:0xe000eda0>

--- a/tools/add-yarg-stdlib.sh
+++ b/tools/add-yarg-stdlib.sh
@@ -2,22 +2,19 @@
 
 FS_PATH="${1:-build/specimen-fs.uf2}"
 
-pushd yarg/specimen > /dev/null
-
-../../bin/yarg cp -fs "../../$FS_PATH" -src gpio.ya -dest gpio.ya
-../../bin/yarg cp -fs "../../$FS_PATH" -src irq.ya -dest irq.ya
-../../bin/yarg cp -fs "../../$FS_PATH" -src machine.ya -dest machine.ya
-../../bin/yarg cp -fs "../../$FS_PATH" -src timer.ya -dest timer.ya
-../../bin/yarg cp -fs "../../$FS_PATH" -src uart.ya -dest uart.ya
-../../bin/yarg cp -fs "../../$FS_PATH" -src reset.ya -dest reset.ya
-../../bin/yarg cp -fs "../../$FS_PATH" -src clock.ya -dest clock.ya
-../../bin/yarg cp -fs "../../$FS_PATH" -src pio.ya -dest pio.ya
-../../bin/yarg cp -fs "../../$FS_PATH" -src pio-instructions.ya -dest pio-instructions.ya
-../../bin/yarg cp -fs "../../$FS_PATH" -src dma.ya -dest dma.ya
-../../bin/yarg cp -fs "../../$FS_PATH" -src ws2812.ya -dest ws2812.ya
-../../bin/yarg cp -fs "../../$FS_PATH" -src apa102.ya -dest apa102.ya
-../../bin/yarg cp -fs "../../$FS_PATH" -src repl.ya -dest repl.ya
-../../bin/yarg cp -fs "../../$FS_PATH" -src yarg.ya -dest yarg.ya
-../../bin/yarg cp -fs "../../$FS_PATH" -src cyarg.ya -dest cyarg.ya
-
-popd > /dev/null
+bin/yarg cp -fs "$FS_PATH" -src yarg/specimen/gpio.ya -dest gpio.ya
+bin/yarg cp -fs "$FS_PATH" -src yarg/specimen/irq.ya -dest irq.ya
+bin/yarg cp -fs "$FS_PATH" -src yarg/specimen/machine.ya -dest machine.ya
+bin/yarg cp -fs "$FS_PATH" -src yarg/specimen/timer.ya -dest timer.ya
+bin/yarg cp -fs "$FS_PATH" -src yarg/specimen/uart.ya -dest uart.ya
+bin/yarg cp -fs "$FS_PATH" -src yarg/specimen/reset.ya -dest reset.ya
+bin/yarg cp -fs "$FS_PATH" -src yarg/specimen/clock.ya -dest clock.ya
+bin/yarg cp -fs "$FS_PATH" -src yarg/specimen/pio.ya -dest pio.ya
+bin/yarg cp -fs "$FS_PATH" -src yarg/specimen/pio-instructions.ya -dest pio-instructions.ya
+bin/yarg cp -fs "$FS_PATH" -src yarg/specimen/dma.ya -dest dma.ya
+bin/yarg cp -fs "$FS_PATH" -src yarg/specimen/ws2812.ya -dest ws2812.ya
+bin/yarg cp -fs "$FS_PATH" -src yarg/specimen/apa102.ya -dest apa102.ya
+bin/yarg cp -fs "$FS_PATH" -src yarg/specimen/m0plus.ya -dest m0plus.ya
+bin/yarg cp -fs "$FS_PATH" -src yarg/specimen/repl.ya -dest repl.ya
+bin/yarg cp -fs "$FS_PATH" -src yarg/specimen/yarg.ya -dest yarg.ya
+bin/yarg cp -fs "$FS_PATH" -src yarg/specimen/cyarg.ya -dest cyarg.ya

--- a/tools/benchmark-pico.sh
+++ b/tools/benchmark-pico.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-BENCHMARKS="fib int-perform equality string_equality instantiation invocation \
+BENCHMARKS="fib stable-interrupt int-perform equality string_equality instantiation invocation \
                 method_call properties trees zoo zoo_batch binary_trees"
 
 ./tools/build-benchmark.sh

--- a/tools/build-benchmark.sh
+++ b/tools/build-benchmark.sh
@@ -15,7 +15,7 @@ cp ../../build/yarg-lang.uf2 $TARGETUF2
 for y in binary_trees.ya equality.ya fib.ya instantiation.ya \
          int-perform.ya invocation.ya method_call.ya \
          properties.ya string_equality.ya trees.ya zoo_batch.ya \
-         zoo.ya
+         zoo.ya stable-interrupt.ya
 do
     $HOSTYARG cp -fs $TARGETUF2 -src $y -dest $y
 done

--- a/yarg/specimen/m0plus.ya
+++ b/yarg/specimen/m0plus.ya
@@ -1,0 +1,25 @@
+place struct {
+    uint32@0xe010 syst_csr;
+    uint32 syst_rvr;
+    uint32 syst_cvr;
+    uint32 syst_calib;
+    uint32@0xe100 nvic_iser;
+    uint32@0xe180 nvic_icer;
+    uint32@0xe200 nvic_ispr;
+    uint32@0xe280 nvic_icpr;
+    uint32[8]@0xe400 nvic_ipr;
+    uint32@0xed00 cpuid;
+    uint32 icsr;
+    uint32 vtor;
+    uint32 aircr;
+    uint32 scr;
+    uint32 ccr;
+    uint32@0xed1c shpr2;
+    uint32 shpr3;        
+    uint32 shcsr;
+    uint32@0xed90 mpu_type;
+    uint32 mpu_ctrl;
+    uint32 mpu_rnr;
+    uint32 mpu_rbar;
+    uint32 mpu_rasr;
+    } @xe0000000 m0plus;

--- a/yarg/specimen/yarg.ya
+++ b/yarg/specimen/yarg.ya
@@ -55,6 +55,9 @@ fun import(library) {
         } else {
             lib();
         }
+    } else if (yarg_imports[library] == nil and library != "main") {
+        print "Library search: " + yarg_library_path;
+        print "Library not found: " + library;
     }
 }
 


### PR DESCRIPTION
Addresses #164, but may currently be incomplete.

Temporarily (!) reduces the iterations in Blinky, due to the extra spinlocks now needed by the VM.