### PR TITLE
Restructure print to work from a string

### DIFF
--- a/cyarg/ast.c
+++ b/cyarg/ast.c
@@ -312,7 +312,7 @@ void printCallArgs(DynamicObjArray* args) {
 
 void printExprDot(ObjExprDot* dot) {
     printf(".");
-    printObject(OBJ_VAL(dot->name));
+    printValue(OBJ_VAL(dot->name));
     if (dot->assignment) {
         printf(" = ");
         printExpr(dot->assignment);
@@ -323,7 +323,7 @@ void printExprDot(ObjExprDot* dot) {
 
 void printExprSuper(ObjExprSuper* expr) {
     printf("super.");
-    printObject(OBJ_VAL(expr->name));
+    printValue(OBJ_VAL(expr->name));
     if (expr->call) {
         printExpr((ObjExpr*)expr->call);
     }
@@ -441,7 +441,7 @@ void printExpr(ObjExpr* expr) {
             }
             case OBJ_EXPR_NAMEDVARIABLE: {
                 ObjExprNamedVariable* var = (ObjExprNamedVariable*)cursor;
-                printObject(OBJ_VAL(var->name));
+                printValue(OBJ_VAL(var->name));
                 if (var->assignment) {
                     printf(" = ");
                     printExpr(var->assignment);
@@ -460,7 +460,7 @@ void printExpr(ObjExpr* expr) {
             case OBJ_EXPR_STRING: {
                 ObjExprString* str = (ObjExprString*)cursor;
                 printf("\"");
-                printObject(OBJ_VAL(str->string));
+                printValue(OBJ_VAL(str->string));
                 printf("\"");
                 break;
             }
@@ -524,7 +524,7 @@ void printStmtIf(ObjStmtIf* ctrl) {
 
 void printFunDeclaration(ObjStmtFunDeclaration* decl) {
     printf("fun ");
-    printObject(OBJ_VAL(decl->name));
+    printValue(OBJ_VAL(decl->name));
     printCallArgs(&decl->parameters);
     printf("\n");
     printIndentation();
@@ -555,7 +555,7 @@ void printStmtFor(ObjStmtFor* loop) {
 
 void printStmtClassDeclaration(ObjStmtClassDeclaration* class_) {
     printf("class ");
-    printObject(OBJ_VAL(class_->name));
+    printValue(OBJ_VAL(class_->name));
     if (class_->superclass) {
         printf(" < ");
         printExpr(class_->superclass);
@@ -602,7 +602,7 @@ void printStmtVarDeclaration(ObjStmtVarDeclaration* decl) {
         printExpr(decl->type);
     }
     printf(" ");
-    printObject(OBJ_VAL(decl->name));
+    printValue(OBJ_VAL(decl->name));
     if (decl->initialiser) {
         printf(" = ");
         printExpr(decl->initialiser);
@@ -613,7 +613,7 @@ void printStmtVarDeclaration(ObjStmtVarDeclaration* decl) {
 static void printAliasDeclaration(ObjPlaceAlias* alias) {
     printExpr(alias->location);
     printf(" ");
-    printObject(OBJ_VAL(alias->name));
+    printValue(OBJ_VAL(alias->name));
     printf(";");
 }
 
@@ -660,7 +660,7 @@ static void printStmtFieldDeclaration(ObjStmtFieldDeclaration* decl) {
         printf(" ");
     }
 
-    printObject(OBJ_VAL(decl->name));
+    printValue(OBJ_VAL(decl->name));
     printf(";");
 }
 

--- a/cyarg/builtin.c
+++ b/cyarg/builtin.c
@@ -952,59 +952,8 @@ bool floatBuiltin(ObjRoutine* routineContext, int argCount, Value* result) {
 
 bool stringBuiltin(ObjRoutine* routineContext, int argCount, Value* result) {
     Value arg = nativeArgument(routineContext, argCount, 0);
-    int64_t i;
-    if (IS_I8(arg)) {
-        i = AS_I8(arg);
-    } else if (IS_I16(arg)) {
-        i = AS_I16(arg);
-    } else if (IS_I32(arg)) {
-        i = AS_I32(arg);
-    } else if (IS_I64(arg)) {
-        i = AS_I64(arg);
-    } else if (IS_UI8(arg)) {
-        i = AS_UI8(arg);
-    } else if (IS_UI16(arg)) {
-        i = AS_UI16(arg);
-    } else if (IS_UI32(arg)) {
-        i = AS_UI32(arg);
-    } else if (IS_UI64(arg)) {
-        uint64_t i = AS_UI64(arg);
-        char sb[22];
-        int l = snprintf(sb, 22, "%" PRIu64, i);
-        ObjString* string = copyString(sb, l);
-        result->as.obj = &string->obj;
-        result->type = VAL_OBJ;
-        return true;
-    } else if (IS_STRING(arg)) {
-        ObjString *string = AS_STRING(arg);
-        result->as.obj = &string->obj;
-        result->type = VAL_OBJ;
-        return true;
-    } else if (IS_INT(arg)) {
-        char sb[INT_STRLEN_FOR_INT254];
-        Int *i = AS_INT(arg);
-        char const *s = int_to_s(i, sb, INT_STRLEN_FOR_INT254);
-        int len = (int)strlen(s);
-        ObjString* string = copyString(s, len);
-        result->as.obj = &string->obj;
-        result->type = VAL_OBJ;
-        return true;
-    } else if (IS_DOUBLE(arg)) {
-        char sb[22];
-        double f = AS_DOUBLE(arg);
-        int l = snprintf(sb, 22, "%#g", f);
-        ObjString* string = copyString(sb, l);
-        result->as.obj = &string->obj;
-        result->type = VAL_OBJ;
-        return true;
-    } else {
-        return false;
-    }
-    char sb[22];
-    int l = snprintf(sb, 22, "%" PRId64, i);
-    ObjString* string = copyString(sb, l);
-    result->as.obj = &string->obj;
-    result->type = VAL_OBJ;
+    ObjString* representation = valueToString(arg);
+    *result = OBJ_VAL(representation);
     return true;
 }
 

--- a/cyarg/channel.c
+++ b/cyarg/channel.c
@@ -93,16 +93,19 @@ void markChannel(ObjChannelContainer* channel) {
 ObjString* channelToString(ObjChannelContainer* channel) {
     char buffer[256];
     snprintf(buffer, sizeof(buffer), "channel{");
+    size_t string_cursor = strlen(buffer);
     size_t cursor = readCursor(channel);
     for (int i = 0; i < channel->occupied; i++) {
         ObjString* valueStr = valueToString(channel->buffer[cursor]);
-        snprintf(buffer, sizeof(buffer), "%s%s", buffer, valueStr->chars);
+        snprintf(buffer + string_cursor, sizeof(buffer) - string_cursor, "%s", valueStr->chars);
+        string_cursor = strlen(buffer);
         if (i < channel->occupied - 1) {
-            snprintf(buffer, sizeof(buffer), "%s, ", buffer);
+            snprintf(buffer + string_cursor, sizeof(buffer) - string_cursor, ", ");
+            string_cursor = strlen(buffer);
         }
         cursor = (cursor + 1) % channel->bufferSize;
     }
-    snprintf(buffer, sizeof(buffer), "%s}", buffer);
+    snprintf(buffer + string_cursor, sizeof(buffer) - string_cursor, "}");
     return copyString(buffer, (int)strlen(buffer));
 }
 

--- a/cyarg/channel.c
+++ b/cyarg/channel.c
@@ -90,17 +90,20 @@ void markChannel(ObjChannelContainer* channel) {
     }
 }
 
-void printChannel(FILE* op, ObjChannelContainer* channel) {
-    FPRINTMSG(op, "channel{");
+ObjString* channelToString(ObjChannelContainer* channel) {
+    char buffer[256];
+    snprintf(buffer, sizeof(buffer), "channel{");
     size_t cursor = readCursor(channel);
     for (int i = 0; i < channel->occupied; i++) {
-        fprintValue(op, channel->buffer[cursor]);
+        ObjString* valueStr = valueToString(channel->buffer[cursor]);
+        snprintf(buffer, sizeof(buffer), "%s%s", buffer, valueStr->chars);
         if (i < channel->occupied - 1) {
-            FPRINTMSG(op, ", ");
+            snprintf(buffer, sizeof(buffer), "%s, ", buffer);
         }
         cursor = (cursor + 1) % channel->bufferSize;
     }
-    FPRINTMSG(op, "}");
+    snprintf(buffer, sizeof(buffer), "%s}", buffer);
+    return copyString(buffer, (int)strlen(buffer));
 }
 
 void sendChannel(ObjChannelContainer* channel, Value data) {

--- a/cyarg/channel.h
+++ b/cyarg/channel.h
@@ -13,7 +13,7 @@ ObjChannelContainer* newChannel(ObjRoutine* routine, size_t capacity);
 void freeChannelObject(Obj* channel);
 void markChannel(ObjChannelContainer* channel);
 
-void printChannel(FILE* op, ObjChannelContainer* channel);
+ObjString* channelToString(ObjChannelContainer* channel);
 
 void sendChannel(ObjChannelContainer* channel, Value data);
 Value receiveChannel(ObjChannelContainer* channel);

--- a/cyarg/debug.c
+++ b/cyarg/debug.c
@@ -336,7 +336,22 @@ void printValueStack(ObjRoutine* routine, const char* message) {
         printf("[ ");
         printValue(slot->value);
         printf(" | ");
-        printType(stdout, slot->cellType);
+        printValue(OBJ_VAL((Obj*)slot->cellType));
+        printf(" ]");
+    }
+    printf("\n");
+}
+
+void traceValueStack(ObjRoutine* routine, const char* message) {
+    size_t stackSize = routine->stackTopIndex;
+    printf("%6s", message);
+    printf("%3zu:", stackSize);
+    for (int i = (int)(stackSize - 1); i >= 0; i--) {
+        ValueCell* slot = peekCell(routine, i);
+        printf("[ ");
+        printValue(slot->value);
+        printf(" | ");
+        printValue(OBJ_VAL((Obj*)slot->cellType));
         printf(" ]");
     }
     printf("\n");

--- a/cyarg/debug.c
+++ b/cyarg/debug.c
@@ -336,7 +336,8 @@ void printValueStack(ObjRoutine* routine, const char* message) {
         printf("[ ");
         printValue(slot->value);
         printf(" | ");
-        printValue(OBJ_VAL((Obj*)slot->cellType));
+        Obj* cellTypeObj = (Obj*)slot->cellType;
+        printValue(cellTypeObj == NULL ? NIL_VAL : OBJ_VAL(cellTypeObj));
         printf(" ]");
     }
     printf("\n");
@@ -351,7 +352,8 @@ void traceValueStack(ObjRoutine* routine, const char* message) {
         printf("[ ");
         printValue(slot->value);
         printf(" | ");
-        printValue(OBJ_VAL((Obj*)slot->cellType));
+        Obj* cellTypeObj = (Obj*)slot->cellType;
+        printValue(cellTypeObj == NULL ? NIL_VAL : OBJ_VAL(cellTypeObj));
         printf(" ]");
     }
     printf("\n");

--- a/cyarg/debug.h
+++ b/cyarg/debug.h
@@ -6,5 +6,6 @@
 void disassembleChunk(Chunk* chunk, const char* name);
 int disassembleInstruction(Chunk* chunk, int offset);
 void printValueStack(ObjRoutine* routine, const char* message);
+void traceValueStack(ObjRoutine* routine, const char* message);
 
 #endif

--- a/cyarg/object.c
+++ b/cyarg/object.c
@@ -445,122 +445,138 @@ ObjUpvalue* newUpvalue(ValueCell* slot, size_t stackOffset) {
     return upvalue;
 }
 
-static void printFunction(FILE* op, ObjFunction* function) {
+static ObjString* functionToString(ObjFunction* function) {
     if (function->fName == NULL) {
-        FPRINTMSG(op, "<script>");
-        return;
+        return copyString("<script>", 8);
     }
-    FPRINTMSG(op, "<fn %s>", function->fName->chars);
+    char buffer[64];
+    snprintf(buffer, sizeof(buffer), "<fn %s>", function->fName->chars);
+    return copyString(buffer, (int)strlen(buffer));
 }
 
-static void printRoutine(FILE* op, ObjRoutine* routine) {
-    FPRINTMSG(op, "<R%p>", routine);
+static ObjString* routineToString(ObjRoutine* routine) {
+    char buffer[64];
+    snprintf(buffer, sizeof(buffer), "<R%p>", routine);
+    return copyString(buffer, (int)strlen(buffer));
 }
 
-static void printArray(FILE* op, ObjPackedUniformArray* array) {
+static ObjString* arrayToString(ObjPackedUniformArray* array) {
     ObjConcreteYargTypeArray* arrayType = (ObjConcreteYargTypeArray*)array->store.storedType;
-    printType(op, array->store.storedType);
-    FPRINTMSG(op, ":[");
+    char buffer[1024];
+    ObjString* typeStr = valueToString(OBJ_VAL(arrayType));
+    snprintf(buffer, sizeof(buffer), "%s:[", typeStr->chars);
     for (int i = 0; i < arrayType->cardinality; i++) {
         PackedValue element = arrayElement(array->store, i);
         Value unpackedValue = unpackValue(element);
-        fprintValue(op, unpackedValue);
+        ObjString* candidate = valueToString(unpackedValue);
+        snprintf(buffer, sizeof(buffer), "%s%s", buffer, candidate->chars);
         if (i < arrayType->cardinality - 1) {
-            FPRINTMSG(op, ", ");
+            snprintf(buffer, sizeof(buffer), "%s, ", buffer);
         }
     }
-    FPRINTMSG(op, "]");
+    snprintf(buffer, sizeof(buffer), "%s]", buffer);
+    return copyString(buffer, (int)strlen(buffer));
 }
 
-static void printPointer(FILE* op, ObjPackedPointer* ptr) {
-    FPRINTMSG(op, "<*");
+static ObjString* pointerToString(ObjPackedPointer* ptr) {
     Value targetType = ptr->type->target_type == NULL ? NIL_VAL : OBJ_VAL(ptr->type->target_type);
-    fprintValue(op, targetType);
-    FPRINTMSG(op, ":%p>", (void*) ptr->destination);
+    ObjString* targetTypeStr = valueToString(targetType);
+
+    char buffer[64];
+    snprintf(buffer, sizeof(buffer), "<*%s:%p>", targetTypeStr->chars, (void*) ptr->destination);
+    return copyString(buffer, (int)strlen(buffer));
 }
 
-static void printStruct(FILE* op, ObjPackedStruct* st) {
+static ObjString* structToString(ObjPackedStruct* st) {
     ObjConcreteYargTypeStruct* structType = (ObjConcreteYargTypeStruct*)st->store.storedType;
-    FPRINTMSG(op, "struct{|%zu:%zu|", structType->field_count, structType->storage_size);
+    char buffer[1024];
+    snprintf(buffer, sizeof(buffer), "struct{|%zu:%zu|", structType->field_count, structType->storage_size);
     for (size_t i = 0; i < structType->field_count; i++) {
         PackedValue f = structField(st->store, i);
         Value logValue = unpackValue(f);
-        fprintValue(op, logValue);
-        FPRINTMSG(op, "; ");
+        ObjString* fieldStr = valueToString(logValue);
+        snprintf(buffer, sizeof(buffer), "%s%s; ", buffer, fieldStr->chars);
     }
-    FPRINTMSG(op, "}");
+    snprintf(buffer, sizeof(buffer), "%s}", buffer);
+    return copyString(buffer, (int)strlen(buffer));
 }
 
-void fprintObject(FILE* op, Value value) {
+ObjString* mapToString(ObjMap* map) {
+    ObjString* typeStr = valueToString(OBJ_VAL(map->type));
+    char buffer[64];
+    snprintf(buffer, sizeof(buffer), "<map (%d) %s >", map->entries.count, typeStr->chars);
+    return copyString(buffer, (int)strlen(buffer));
+}
+
+ObjString* objectToString(Value value) {
     switch (OBJ_TYPE(value)) {
         case OBJ_BOUND_METHOD:
-            printFunction(op, AS_BOUND_METHOD(value)->method->function);
-            break;
+            return functionToString(AS_BOUND_METHOD(value)->method->function);
         case OBJ_CLASS:
-            FPRINTMSG(op, "%s", AS_CLASS(value)->name->chars);
-            break;
+            return copyString(AS_CLASS(value)->name->chars, AS_CLASS(value)->name->length);
         case OBJ_CLOSURE:
-            printFunction(op, AS_CLOSURE(value)->function);
-            break;
+            return functionToString(AS_CLOSURE(value)->function);
         case OBJ_FUNCTION:
-            printFunction(op, AS_FUNCTION(value));
-            break;
-        case OBJ_INSTANCE:
-            FPRINTMSG(op, "%s instance", AS_INSTANCE(value)->klass->name->chars);
-            break;
+            return functionToString(AS_FUNCTION(value));
+        case OBJ_INSTANCE: {
+            char buffer[64];
+            snprintf(buffer, sizeof(buffer), "%s instance", AS_INSTANCE(value)->klass->name->chars);
+            return copyString(buffer, (int)strlen(buffer));
+            }
         case OBJ_NATIVE:
-            FPRINTMSG(op, "<native fn>");
-            break;
+            return copyString("<native fn>", 11);
         case OBJ_ROUTINE:
-            printRoutine(op, AS_ROUTINE(value));
+            return routineToString(AS_ROUTINE(value));
             break;
         case OBJ_CHANNELCONTAINER:
-            printChannel(op, AS_CHANNEL(value));
+            return channelToString(AS_CHANNEL(value));
             break;
         case OBJ_SYNCGROUP:
-            printSyncGroup(op, AS_SYNCGROUP(value));
+            return syncGroupToString(AS_SYNCGROUP(value));
             break;
         case OBJ_STRING:
-            FPRINTMSG(op, "%s", AS_CSTRING(value));
+            return copyString(AS_CSTRING(value), AS_STRING(value)->length);
             break;
         case OBJ_UPVALUE:
-            FPRINTMSG(op, "upvalue");
+            return copyString("upvalue", 7);
             break;
         case OBJ_UNOWNED_UNIFORMARRAY:
         case OBJ_PACKEDUNIFORMARRAY:
-            printArray(op, AS_UNIFORMARRAY(value));
+            return arrayToString(AS_UNIFORMARRAY(value));
             break;
         case OBJ_YARGTYPE:
         case OBJ_YARGTYPE_ARRAY:
         case OBJ_YARGTYPE_STRUCT:
         case OBJ_YARGTYPE_MAP:
-            printType(op, AS_YARGTYPE(value));
+            return typeToString(AS_YARGTYPE(value));
             break;
         case OBJ_UNOWNED_PACKEDPOINTER:
         case OBJ_PACKEDPOINTER:
-            printPointer(op, AS_POINTER(value));
+            return pointerToString(AS_POINTER(value));
             break;
         case OBJ_UNOWNED_PACKEDSTRUCT:
         case OBJ_PACKEDSTRUCT:
-            printStruct(op, AS_STRUCT(value));
+            return structToString(AS_STRUCT(value));
             break;
         case OBJ_INT: {
             Int *i = AS_INT(value);
             char sb[INT_STRLEN_FOR_INT254];
             char const* s = int_to_s(i, sb, INT_STRLEN_FOR_INT254);
-            FPRINTMSG(op, "%s", s);
-            break;
+            return copyString(s, (int)strlen(s));
         }
         case OBJ_MAP:
-            FPRINTMSG(op, "<map ");
-            FPRINTMSG(op, "(%d) ", AS_MAP(value)->entries.count);
-            printType(op, (ObjConcreteYargType*)(AS_MAP(value)->type));
-            FPRINTMSG(op, " >");
-            break;
-        default:
-            FPRINTMSG(op, "<implementation object %d>", OBJ_TYPE(value));
-            break;
+            return mapToString(AS_MAP(value));
+        default: {
+                char buffer[64];
+                snprintf(buffer, sizeof(buffer), "<implementation object %d>", OBJ_TYPE(value));
+                return copyString(buffer, (int)strlen(buffer));
+            }
     }
+}
+
+void fprintObject(FILE* op, Value value) {
+    ObjString* str = objectToString(value);
+    FPRINTMSG(op, "%s", str->chars);
 }
 
 void printObject(Value value) {

--- a/cyarg/object.c
+++ b/cyarg/object.c
@@ -465,16 +465,19 @@ static ObjString* arrayToString(ObjPackedUniformArray* array) {
     char buffer[1024];
     ObjString* typeStr = valueToString(OBJ_VAL(arrayType));
     snprintf(buffer, sizeof(buffer), "%s:[", typeStr->chars);
+    size_t cursor = strlen(buffer);
     for (int i = 0; i < arrayType->cardinality; i++) {
         PackedValue element = arrayElement(array->store, i);
         Value unpackedValue = unpackValue(element);
         ObjString* candidate = valueToString(unpackedValue);
-        snprintf(buffer, sizeof(buffer), "%s%s", buffer, candidate->chars);
+        snprintf(buffer + cursor, sizeof(buffer) - cursor, "%s", candidate->chars);
+        cursor = strlen(buffer);
         if (i < arrayType->cardinality - 1) {
-            snprintf(buffer, sizeof(buffer), "%s, ", buffer);
+            snprintf(buffer + cursor, sizeof(buffer) - cursor, ", ");
+            cursor = strlen(buffer);
         }
     }
-    snprintf(buffer, sizeof(buffer), "%s]", buffer);
+    snprintf(buffer + cursor, sizeof(buffer) - cursor, "]");
     return copyString(buffer, (int)strlen(buffer));
 }
 
@@ -504,13 +507,15 @@ static ObjString* structToString(ObjPackedStruct* st) {
     ObjConcreteYargTypeStruct* structType = (ObjConcreteYargTypeStruct*)st->store.storedType;
     char buffer[1024];
     snprintf(buffer, sizeof(buffer), "struct{|%zu:%zu|", structType->field_count, structType->storage_size);
+    size_t cursor = strlen(buffer);
     for (size_t i = 0; i < structType->field_count; i++) {
         PackedValue f = structField(st->store, i);
         Value logValue = unpackValue(f);
         ObjString* fieldStr = valueToString(logValue);
-        snprintf(buffer, sizeof(buffer), "%s%s; ", buffer, fieldStr->chars);
+        snprintf(buffer + cursor, sizeof(buffer) - cursor, "%s; ", fieldStr->chars);
+        cursor = strlen(buffer);
     }
-    snprintf(buffer, sizeof(buffer), "%s}", buffer);
+    snprintf(buffer + cursor, sizeof(buffer) - cursor, "}");
     return copyString(buffer, (int)strlen(buffer));
 }
 

--- a/cyarg/object.c
+++ b/cyarg/object.c
@@ -481,10 +481,23 @@ static ObjString* arrayToString(ObjPackedUniformArray* array) {
 static ObjString* pointerToString(ObjPackedPointer* ptr) {
     Value targetType = ptr->type->target_type == NULL ? NIL_VAL : OBJ_VAL(ptr->type->target_type);
     ObjString* targetTypeStr = valueToString(targetType);
+    tempRootPush(OBJ_VAL(targetTypeStr));
 
-    char buffer[64];
-    snprintf(buffer, sizeof(buffer), "<*%s:%p>", targetTypeStr->chars, (void*) ptr->destination);
-    return copyString(buffer, (int)strlen(buffer));
+    ObjString* prefix = copyString("<*", 2);
+    tempRootPush(OBJ_VAL(prefix));
+    ObjString* working = concatenateStrings(prefix, targetTypeStr);
+    tempRootPush(OBJ_VAL(working));
+    
+    int length = working->length + 12;
+    char* chars = ALLOCATE(char, length + 1);
+    memcpy(chars, working->chars, working->length);
+    snprintf(chars + working->length, 12 + 1, ":%p>", (void*) ptr->destination);
+
+    ObjString* result = takeString(chars, length);
+    tempRootPop();
+    tempRootPop();
+    tempRootPop();
+    return result;
 }
 
 static ObjString* structToString(ObjPackedStruct* st) {

--- a/cyarg/object.c
+++ b/cyarg/object.c
@@ -586,12 +586,3 @@ ObjString* objectToString(Value value) {
             }
     }
 }
-
-void fprintObject(FILE* op, Value value) {
-    ObjString* str = objectToString(value);
-    FPRINTMSG(op, "%s", str->chars);
-}
-
-void printObject(Value value) {
-    fprintObject(stdout, value);
-}

--- a/cyarg/object.h
+++ b/cyarg/object.h
@@ -257,8 +257,6 @@ Value defaultStructValue(ObjConcreteYargType* type);
 
 Value placeObjectAt(Value type, Value location);
 
-void printObject(Value value);
-void fprintObject(FILE* op, Value value);
 ObjString* objectToString(Value value);
 
 static inline bool isObjType(Value value, ObjType type) {

--- a/cyarg/object.h
+++ b/cyarg/object.h
@@ -259,6 +259,7 @@ Value placeObjectAt(Value type, Value location);
 
 void printObject(Value value);
 void fprintObject(FILE* op, Value value);
+ObjString* objectToString(Value value);
 
 static inline bool isObjType(Value value, ObjType type) {
     return IS_OBJ(value) && AS_OBJ(value)->type == type;

--- a/cyarg/sync_group.c
+++ b/cyarg/sync_group.c
@@ -42,11 +42,14 @@ void markSyncGroup(ObjSyncGroup* group) {
     markObject((Obj*)group->result_array);
 }
 
-void printSyncGroup(FILE* op, ObjSyncGroup* group) {
-    FPRINTMSG(op, "sync_group{");
+ObjString* syncGroupToString(ObjSyncGroup* group) {
+    char buffer[256];
+    snprintf(buffer, sizeof(buffer), "sync_group{");
     Value results = unpackValue(group->result_array->store);
-    fprintValue(op, results);
-    FPRINTMSG(op, "}");
+    ObjString* resultsStr = valueToString(results);
+    snprintf(buffer, sizeof(buffer), "%s%s", buffer, resultsStr->chars);
+    snprintf(buffer, sizeof(buffer), "%s}", buffer);
+    return copyString(buffer, (int)strlen(buffer));
 }
 
 Value receiveSyncGroup(ObjSyncGroup* group) {

--- a/cyarg/sync_group.c
+++ b/cyarg/sync_group.c
@@ -45,10 +45,12 @@ void markSyncGroup(ObjSyncGroup* group) {
 ObjString* syncGroupToString(ObjSyncGroup* group) {
     char buffer[256];
     snprintf(buffer, sizeof(buffer), "sync_group{");
+    size_t cursor = strlen(buffer);
     Value results = unpackValue(group->result_array->store);
     ObjString* resultsStr = valueToString(results);
-    snprintf(buffer, sizeof(buffer), "%s%s", buffer, resultsStr->chars);
-    snprintf(buffer, sizeof(buffer), "%s}", buffer);
+    snprintf(buffer + cursor, sizeof(buffer) - cursor, "%s", resultsStr->chars);
+    cursor = strlen(buffer);
+    snprintf(buffer + cursor, sizeof(buffer) - cursor, "}");
     return copyString(buffer, (int)strlen(buffer));
 }
 

--- a/cyarg/sync_group.h
+++ b/cyarg/sync_group.h
@@ -13,7 +13,7 @@ ObjSyncGroup* newSyncGroup(ObjRoutine* routine, ObjPackedUniformArray* items);
 void freeSyncGroup(Obj* group);
 void markSyncGroup(ObjSyncGroup* group);
 
-void printSyncGroup(FILE* op, ObjSyncGroup* group);
+ObjString* syncGroupToString(ObjSyncGroup* group);
 
 Value receiveSyncGroup(ObjSyncGroup* group);
 

--- a/cyarg/table.c
+++ b/cyarg/table.c
@@ -315,7 +315,7 @@ void printCellTable(ValueCellTable* table) {
             FPRINTMSG(stderr, ":::");
             printValue(entry->cell.value);
             FPRINTMSG(stderr, ":::");
-            printType(stderr, entry->cell.cellType);
+            printObject(OBJ_VAL((Obj*)entry->cell.cellType));
             FPRINTMSG(stderr, "\n");
         }
     }

--- a/cyarg/table.c
+++ b/cyarg/table.c
@@ -311,11 +311,11 @@ void printCellTable(ValueCellTable* table) {
     for (int i = 0; i < table->capacity; i++) {
         EntryCell* entry = &table->entries[i];
         if (entry->key != NULL) {
-            printObject(OBJ_VAL((Obj*)entry->key));
+            printValue(OBJ_VAL((Obj*)entry->key));
             FPRINTMSG(stderr, ":::");
             printValue(entry->cell.value);
             FPRINTMSG(stderr, ":::");
-            printObject(OBJ_VAL((Obj*)entry->cell.cellType));
+            printValue(OBJ_VAL((Obj*)entry->cell.cellType));
             FPRINTMSG(stderr, "\n");
         }
     }

--- a/cyarg/value.c
+++ b/cyarg/value.c
@@ -371,8 +371,91 @@ void freeDynamicValueArray(DynamicValueArray* array) {
     initDynamicValueArray(array);
 }
 
+ObjString* doubleToString(double value) {
+    char buffer[32];
+    snprintf(buffer, sizeof(buffer), "%#g", value);
+    return copyString(buffer, (int)strlen(buffer));
+}
+
+ObjString* i8ToString(int8_t value) {
+    char buffer[32];
+    snprintf(buffer, sizeof(buffer), "%d", value);
+    return copyString(buffer, (int)strlen(buffer));
+}
+
+ObjString* ui8ToString(uint8_t value) {
+    char buffer[32];
+    snprintf(buffer, sizeof(buffer), "%u", value);
+    return copyString(buffer, (int)strlen(buffer));
+}
+
+ObjString* i16ToString(int16_t value) {
+    char buffer[32];
+    snprintf(buffer, sizeof(buffer), "%d", value);
+    return copyString(buffer, (int)strlen(buffer));
+}
+
+ObjString* ui16ToString(uint16_t value) {
+    char buffer[32];
+    snprintf(buffer, sizeof(buffer), "%u", value);
+    return copyString(buffer, (int)strlen(buffer));
+}
+
+ObjString* i32ToString(int32_t value) {
+    char buffer[32];
+    snprintf(buffer, sizeof(buffer), "%d", value);
+    return copyString(buffer, (int)strlen(buffer));
+}
+
+ObjString* ui32ToString(uint32_t value) {
+    char buffer[32];
+    snprintf(buffer, sizeof(buffer), "%u", value);
+    return copyString(buffer, (int)strlen(buffer));
+}
+
+ObjString* i64ToString(int64_t value) {
+    char buffer[32];
+    snprintf(buffer, sizeof(buffer), "%" PRId64, value);
+    return copyString(buffer, (int)strlen(buffer));
+}
+
+ObjString* ui64ToString(uint64_t value) {
+    char buffer[32];
+    snprintf(buffer, sizeof(buffer), "%" PRIu64, value);
+    return copyString(buffer, (int)strlen(buffer));
+}
+
+ObjString* addressToString(uintptr_t value) {
+    char buffer[32];
+    snprintf(buffer, sizeof(buffer), "%p", (void*)value);
+    return copyString(buffer, (int)strlen(buffer));
+}
+
+ObjString* valueToString(Value value) {
+    ObjString* string = NULL;
+    switch (value.type) {
+        case VAL_BOOL:
+            string = AS_BOOL(value) ? copyString("true", 4) : copyString("false", 5);
+            break;
+        case VAL_NIL: string = copyString("nil", 3); break;
+        case VAL_DOUBLE: string = doubleToString(AS_DOUBLE(value)); break;
+        case VAL_I8: string = i8ToString(AS_I8(value)); break;
+        case VAL_UI8: string = ui8ToString(AS_UI8(value)); break;
+        case VAL_I16: string = i16ToString(AS_I16(value)); break;
+        case VAL_UI16: string = ui16ToString(AS_UI16(value)); break;
+        case VAL_I32: string = i32ToString(AS_I32(value)); break;
+        case VAL_UI32: string = ui32ToString(AS_UI32(value)); break;
+        case VAL_I64: string = i64ToString(AS_I64(value)); break;
+        case VAL_UI64: string = ui64ToString(AS_UI64(value)); break;
+        case VAL_ADDRESS: string = addressToString(AS_ADDRESS(value)); break;
+        case VAL_OBJ: string = objectToString(value); break;
+    }
+    return string;
+}
+
 void printValue(Value value) {
-    fprintValue(stdout, value);
+    ObjString* string = valueToString(value);
+    printf("%s", string->chars);
 }
 
 void fprintValue(FILE* op, Value value) {

--- a/cyarg/value.c
+++ b/cyarg/value.c
@@ -371,6 +371,18 @@ void freeDynamicValueArray(DynamicValueArray* array) {
     initDynamicValueArray(array);
 }
 
+ObjString* concatenateStrings(ObjString* a, ObjString* b) {
+
+    int length = a->length + b->length;
+    char* chars = ALLOCATE(char, length + 1);
+    memcpy(chars, a->chars, a->length);
+    memcpy(chars + a->length, b->chars, b->length);
+    chars[length] = '\0';
+
+    ObjString* result = takeString(chars, length);
+    return result;
+}
+
 ObjString* doubleToString(double value) {
     char buffer[32];
     snprintf(buffer, sizeof(buffer), "%#g", value);

--- a/cyarg/value.c
+++ b/cyarg/value.c
@@ -390,55 +390,55 @@ ObjString* doubleToString(double value) {
 }
 
 ObjString* i8ToString(int8_t value) {
-    char buffer[32];
+    char buffer[5];
     snprintf(buffer, sizeof(buffer), "%d", value);
     return copyString(buffer, (int)strlen(buffer));
 }
 
 ObjString* ui8ToString(uint8_t value) {
-    char buffer[32];
+    char buffer[4];
     snprintf(buffer, sizeof(buffer), "%u", value);
     return copyString(buffer, (int)strlen(buffer));
 }
 
 ObjString* i16ToString(int16_t value) {
-    char buffer[32];
+    char buffer[7];
     snprintf(buffer, sizeof(buffer), "%d", value);
     return copyString(buffer, (int)strlen(buffer));
 }
 
 ObjString* ui16ToString(uint16_t value) {
-    char buffer[32];
+    char buffer[6];
     snprintf(buffer, sizeof(buffer), "%u", value);
     return copyString(buffer, (int)strlen(buffer));
 }
 
 ObjString* i32ToString(int32_t value) {
-    char buffer[32];
+    char buffer[12];
     snprintf(buffer, sizeof(buffer), "%d", value);
     return copyString(buffer, (int)strlen(buffer));
 }
 
 ObjString* ui32ToString(uint32_t value) {
-    char buffer[32];
+    char buffer[11];
     snprintf(buffer, sizeof(buffer), "%u", value);
     return copyString(buffer, (int)strlen(buffer));
 }
 
 ObjString* i64ToString(int64_t value) {
-    char buffer[32];
+    char buffer[21];
     snprintf(buffer, sizeof(buffer), "%" PRId64, value);
     return copyString(buffer, (int)strlen(buffer));
 }
 
 ObjString* ui64ToString(uint64_t value) {
-    char buffer[32];
+    char buffer[21];
     snprintf(buffer, sizeof(buffer), "%" PRIu64, value);
     return copyString(buffer, (int)strlen(buffer));
 }
 
 ObjString* addressToString(uintptr_t value) {
-    char buffer[32];
+    char buffer[19];
     snprintf(buffer, sizeof(buffer), "%p", (void*)value);
     return copyString(buffer, (int)strlen(buffer));
 }

--- a/cyarg/value.c
+++ b/cyarg/value.c
@@ -466,28 +466,14 @@ ObjString* valueToString(Value value) {
 }
 
 void printValue(Value value) {
-    ObjString* string = valueToString(value);
-    printf("%s", string->chars);
+    fprintValue(stdout, value);
 }
 
 void fprintValue(FILE* op, Value value) {
-    switch (value.type) {
-        case VAL_BOOL:
-            FPRINTMSG(op, AS_BOOL(value) ? "true" : "false");
-            break;
-        case VAL_NIL: FPRINTMSG(op, "nil"); break;
-        case VAL_DOUBLE: FPRINTMSG(op, "%#g", AS_DOUBLE(value)); break;
-        case VAL_I8: FPRINTMSG(op, "%d", AS_I8(value)); break;
-        case VAL_UI8: FPRINTMSG(op, "%u", AS_UI8(value)); break;
-        case VAL_I16: FPRINTMSG(op, "%d", AS_I16(value)); break;
-        case VAL_UI16: FPRINTMSG(op, "%u", AS_UI16(value)); break;
-        case VAL_I32: FPRINTMSG(op, "%d", AS_I32(value)); break;
-        case VAL_UI32: FPRINTMSG(op, "%u", AS_UI32(value)); break;
-        case VAL_I64: FPRINTMSG(op, "%" PRId64, AS_I64(value)); break;
-        case VAL_UI64: FPRINTMSG(op, "%" PRIu64, AS_UI64(value)); break;
-        case VAL_ADDRESS: FPRINTMSG(op, "%p", (void*) AS_ADDRESS(value)); break;
-        case VAL_OBJ: fprintObject(op, value); break;
-    }
+    ObjString* string = valueToString(value);
+    tempRootPush(OBJ_VAL(string));
+    FPRINTMSG(op, "%s", string->chars);
+    tempRootPop();
 }
 
 bool valuesEqual(Value a, Value b) {

--- a/cyarg/value.h
+++ b/cyarg/value.h
@@ -112,6 +112,7 @@ bool valuesEqual(Value a, Value b);
 
 void printValue(Value value);
 void fprintValue(FILE* op, Value value);
+ObjString* valueToString(Value value);
 
 typedef union PackedValueStore PackedValueStore;
 

--- a/cyarg/value.h
+++ b/cyarg/value.h
@@ -110,6 +110,8 @@ uint32_t as_positive_integer32(Value a);
 
 bool valuesEqual(Value a, Value b);
 
+ObjString* concatenateStrings(ObjString* a, ObjString* b);
+
 void printValue(Value value);
 void fprintValue(FILE* op, Value value);
 ObjString* valueToString(Value value);

--- a/cyarg/vm.c
+++ b/cyarg/vm.c
@@ -506,13 +506,7 @@ static void concatenate(ObjRoutine* routine) {
     ObjString* b = AS_STRING(peek(routine, 0));
     ObjString* a = AS_STRING(peek(routine, 1));
 
-    int length = a->length + b->length;
-    char* chars = ALLOCATE(char, length + 1);
-    memcpy(chars, a->chars, a->length);
-    memcpy(chars + a->length, b->chars, b->length);
-    chars[length] = '\0';
-
-    ObjString* result = takeString(chars, length);
+    ObjString* result = concatenateStrings(a, b);
     pop(routine);
     pop(routine);
     push(routine, OBJ_VAL(result));

--- a/cyarg/vm.c
+++ b/cyarg/vm.c
@@ -1156,8 +1156,11 @@ InterpretResult run(ObjRoutine* routine) {
                 break;
             }
             case OP_PRINT: {
-                printValue(pop(routine));
-                printf("\n");
+                ObjString* string = valueToString(peek(routine, 0));
+                tempRootPush(OBJ_VAL(string));
+                printf("%s\n", string->chars);
+                tempRootPop();
+                pop(routine);
                 break;
             }
             case OP_POKE: {

--- a/cyarg/yargtype.c
+++ b/cyarg/yargtype.c
@@ -588,13 +588,15 @@ static ObjString* typeLiteralToString(ObjConcreteYargType* type) {
             ObjConcreteYargTypeStruct* st = (ObjConcreteYargTypeStruct*) type;
             char buffer[1024];
             snprintf(buffer, sizeof(buffer), "struct{|%zu:%zu| ", st->field_count, st->storage_size);
+            size_t cursor = strlen(buffer);
             for (size_t i = 0; i < st->field_count; i++) {
                 ObjString* fieldTypeStr = typeLiteralToString(st->field_types[i]);
                 tempRootPush(OBJ_VAL(fieldTypeStr));
-                snprintf(buffer, sizeof(buffer), "%s%s; ", buffer, fieldTypeStr->chars);
+                snprintf(buffer + cursor, sizeof(buffer) - cursor, "%s; ", fieldTypeStr->chars);
+                cursor = strlen(buffer);
                 tempRootPop();
             }
-            snprintf(buffer, sizeof(buffer), "%s}", buffer);
+            snprintf(buffer + cursor, sizeof(buffer) - cursor, "}");
             return copyString(buffer, (int)strlen(buffer));
         }
         case TypePointer: {

--- a/cyarg/yargtype.c
+++ b/cyarg/yargtype.c
@@ -545,80 +545,91 @@ bool isSupportedMapKeyType(Value type) {
     }
 }
 
-static void printTypeLiteral(FILE* op, ObjConcreteYargType* type) {
+static ObjString* typeLiteralToString(ObjConcreteYargType* type) {
     if (type == NULL) {
-        FPRINTMSG(op, "any");
-        return;
+        return copyString("any", 3);
     }
 
     switch (type->yt) {
-        case TypeAny: FPRINTMSG(op, "any"); break;
-        case TypeBool: FPRINTMSG(op, "bool"); break;
-        case TypeDouble: FPRINTMSG(op, "mfloat64"); break;
-        case TypeInt: FPRINTMSG(op, "int"); break;
-        case TypeInt8: FPRINTMSG(op, "int8"); break;
-        case TypeUint8: FPRINTMSG(op, "uint8"); break;
-        case TypeInt16: FPRINTMSG(op, "int16"); break;
-        case TypeUint16: FPRINTMSG(op, "uint16"); break;
-        case TypeInt32: FPRINTMSG(op, "int32"); break;
-        case TypeUint32: FPRINTMSG(op, "uint32"); break;
-        case TypeInt64: FPRINTMSG(op, "int64"); break;
-        case TypeUint64: FPRINTMSG(op, "uint64"); break;
-        case TypeString: FPRINTMSG(op, "string"); break;
-        case TypeClass: FPRINTMSG(op, "Class"); break;
-        case TypeInstance: FPRINTMSG(op, "Instance"); break;
-        case TypeFunction: FPRINTMSG(op, "Function"); break;
-        case TypeRoutine: FPRINTMSG(op, "Routine"); break;
-        case TypeChannel: FPRINTMSG(op, "Channel"); break;  
-        case TypeYargType: FPRINTMSG(op, "Type"); break;
+        case TypeAny: return copyString("any", 3);
+        case TypeBool: return copyString("bool", 4);
+        case TypeDouble: return copyString("mfloat64", 8);
+        case TypeInt: return copyString("int", 3);
+        case TypeInt8: return copyString("int8", 4);
+        case TypeUint8: return copyString("uint8", 5);
+        case TypeInt16: return copyString("int16", 5);
+        case TypeUint16: return copyString("uint16", 6);
+        case TypeInt32: return copyString("int32", 5);
+        case TypeUint32: return copyString("uint32", 6);
+        case TypeInt64: return copyString("int64", 5);
+        case TypeUint64: return copyString("uint64", 6);
+        case TypeString: return copyString("string", 6);
+        case TypeClass: return copyString("Class", 5);
+        case TypeInstance: return copyString("Instance", 8);
+        case TypeFunction: return copyString("Function", 8);
+        case TypeRoutine: return copyString("Routine", 7);
+        case TypeChannel: return copyString("Channel", 7);
+        case TypeYargType: return copyString("Type", 4);
         case TypeArray: {
             ObjConcreteYargTypeArray* array = (ObjConcreteYargTypeArray*) type;
-            Value type = arrayElementType(array);
-            if (IS_NIL(type)) {
-                FPRINTMSG(op, "any");
-            } else {
-                printTypeLiteral(op, array->element_type);
-            }
-            FPRINTMSG(op, "[");
+            ObjString* typeStr = typeLiteralToString(array->element_type);
+            tempRootPush(OBJ_VAL(typeStr));
+            char buffer[128];
             if (array->cardinality > 0) {
-                FPRINTMSG(op, "%zu", array->cardinality);
+                snprintf(buffer, sizeof(buffer), "%s[%zu]", typeStr->chars, array->cardinality);
+            } else {
+                snprintf(buffer, sizeof(buffer), "%s[]", typeStr->chars);
             }
-            FPRINTMSG(op, "]");
-            break;
+            ObjString* result = copyString(buffer, (int)strlen(buffer));
+            tempRootPop();
+            return result;
         }
         case TypeStruct: {
             ObjConcreteYargTypeStruct* st = (ObjConcreteYargTypeStruct*) type;
-            FPRINTMSG(op, "struct{|%zu:%zu| ", st->field_count, st->storage_size);
+            char buffer[1024];
+            snprintf(buffer, sizeof(buffer), "struct{|%zu:%zu| ", st->field_count, st->storage_size);
             for (size_t i = 0; i < st->field_count; i++) {
-                printTypeLiteral(op, st->field_types[i]);
-                FPRINTMSG(op, "; ");
+                ObjString* fieldTypeStr = typeLiteralToString(st->field_types[i]);
+                tempRootPush(OBJ_VAL(fieldTypeStr));
+                snprintf(buffer, sizeof(buffer), "%s%s; ", buffer, fieldTypeStr->chars);
+                tempRootPop();
             }
-            FPRINTMSG(op, "}");
-            break;
+            snprintf(buffer, sizeof(buffer), "%s}", buffer);
+            return copyString(buffer, (int)strlen(buffer));
         }
         case TypePointer: {
             ObjConcreteYargTypePointer* st = (ObjConcreteYargTypePointer*) type;
-            FPRINTMSG(op, "*");
-            if (st->target_type) {
-                printTypeLiteral(op, st->target_type);
-            } else {
-                FPRINTMSG(op, "any");
-            }
-            break;
+            ObjString* typeStr = typeLiteralToString(st->target_type);
+            tempRootPush(OBJ_VAL(typeStr));
+            char buffer[128];
+            snprintf(buffer, sizeof(buffer), "*%s", typeStr->chars);
+            ObjString* result = copyString(buffer, (int)strlen(buffer));
+            tempRootPop();
+            return result;
         }
         case TypeMap: {
             ObjConcreteYargTypeMap* mt = (ObjConcreteYargTypeMap*) type;
-            printTypeLiteral(op, mt->value_type);
-            FPRINTMSG(op, "[");
-            printTypeLiteral(op, mt->key_type);
-            FPRINTMSG(op, "]");
-            break;
+            ObjString* typeStr = typeLiteralToString(mt->value_type);
+            tempRootPush(OBJ_VAL(typeStr));
+            ObjString* keyTypeStr = typeLiteralToString(mt->key_type);
+            tempRootPush(OBJ_VAL(keyTypeStr));
+            char buffer[128];
+            snprintf(buffer, sizeof(buffer), "%s[%s]", typeStr->chars, keyTypeStr->chars);
+            ObjString* result = copyString(buffer, (int)strlen(buffer));
+            tempRootPop();
+            tempRootPop();
+            return result;
         }
-        default: FPRINTMSG(op, "Unknown"); break;
+        default: {
+            return copyString("Unknown", 7);
+        }
     }
 }
 
-void printType(FILE* op, ObjConcreteYargType* type) {
-    FPRINTMSG(op, "Type:");
-    printTypeLiteral(op, type);
+ObjString* typeToString(ObjConcreteYargType* type) {
+    ObjString* literalStr = typeLiteralToString(type);
+
+    char buffer[64];
+    snprintf(buffer, sizeof(buffer), "Type:%s", literalStr->chars);
+    return copyString(buffer, (int)strlen(buffer));
 }

--- a/cyarg/yargtype.c
+++ b/cyarg/yargtype.c
@@ -628,8 +628,11 @@ static ObjString* typeLiteralToString(ObjConcreteYargType* type) {
 
 ObjString* typeToString(ObjConcreteYargType* type) {
     ObjString* literalStr = typeLiteralToString(type);
-
-    char buffer[64];
-    snprintf(buffer, sizeof(buffer), "Type:%s", literalStr->chars);
-    return copyString(buffer, (int)strlen(buffer));
+    tempRootPush(OBJ_VAL(literalStr));
+    ObjString* prefix = copyString("Type:", 5);
+    tempRootPush(OBJ_VAL(prefix));
+    ObjString* result = concatenateStrings(prefix, literalStr);
+    tempRootPop();
+    tempRootPop();
+    return result;
 }

--- a/cyarg/yargtype.h
+++ b/cyarg/yargtype.h
@@ -89,6 +89,6 @@ bool isInitialisableType(ObjConcreteYargType* lhsType, Value rhsValue, Value *pr
 
 bool isSupportedMapKeyType(Value type);
 
-void printType(FILE* op, ObjConcreteYargType* type);
+ObjString* typeToString(ObjConcreteYargType* type);
 
 #endif

--- a/test/yarg-expect/to_string/to_string.ya
+++ b/test/yarg-expect/to_string/to_string.ya
@@ -52,11 +52,6 @@ print map; // expect: <map (0) Type:any[string] >
 place uint32 @xf0000000 data;
 print data; // expect: <*Type:uint32:0xf0000000>
 
-place struct {
-    uint32@0xe010 test;
-} @xe0000000 test_place;
-print test_place.test; // expect: <*Type:uint32:0xe000e010>
-
-// untested types
+// untested types, at least exercise the to_string function for them
 var r = make_routine(test, true);
-var ptr = new(any);
+print string(r) == string(r); // expect: true

--- a/test/yarg-expect/to_string/to_string.ya
+++ b/test/yarg-expect/to_string/to_string.ya
@@ -1,0 +1,62 @@
+print int(-129);        // expect: -129
+print int(1);         // expect: 1
+print int8(-128);       // expect: -128
+print int8(127);        // expect: 127
+print int16(-32768);    // expect: -32768
+print int16(32767);     // expect: 32767
+print int32(-2147483648); // expect: -2147483648
+print int32(2147483647);  // expect: 2147483647
+print int64(-9223372036854775808); // expect: -9223372036854775808
+print int64(9223372036854775807);  // expect: 9223372036854775807
+print uint8(255);      // expect: 255
+print uint16(65535);   // expect: 65535
+print uint32(4294967295); // expect: 4294967295
+print uint64(18446744073709551615); // expect: 18446744073709551615
+print mfloat64(1.5);  // expect: 1.50000
+print string("hello"); // expect: hello
+print 1 != 1;          // expect: false
+var int[3] a;
+print a;               // expect: Type:int[3]:[0, 0, 0]
+
+var any[2] channels;
+for (var i = 0; i < len(channels); i = i + 1) {
+    channels[i] = make_channel();
+    print channels[i];
+}
+// expect: channel{}
+// expect: channel{}
+var group = make_sync_group(channels);
+print group;            // expect: sync_group{Type:any[2]:[nil, nil]}
+
+fun test() {
+}
+print test;             // expect: <fn test>
+print c_clock_get_hz;   // expect: <native fn>
+
+class Foo {}
+
+print Foo; // expect: Foo
+var foo = Foo();
+print foo; // expect: Foo instance
+
+
+var struct {
+    int x;
+    int y;
+} point;
+print point; // expect: struct{|2:16|0; 0; }
+
+var map = new(any[string]);
+print map; // expect: <map (0) Type:any[string] >
+
+place uint32 @xf0000000 data;
+print data; // expect: <*Type:uint32:0xf0000000>
+
+place struct {
+    uint32@0xe010 test;
+} @xe0000000 test_place;
+print test_place.test; // expect: <*Type:uint32:0xe000e010>
+
+// untested types
+var r = make_routine(test, true);
+var ptr = new(any);


### PR DESCRIPTION
Remove the dependency on printf in OP_PRINT, building language string representations as ObjString first

Part of addressing #142 by separating out tracing from object string representations