### PR TITLE
bug: correctly require uint32 pointers or raw addresses for peek/poke.

### DIFF
--- a/cyarg/builtin.c
+++ b/cyarg/builtin.c
@@ -351,7 +351,7 @@ bool peekBuiltin(ObjRoutine* routineContext, int argCount, Value* result) {
 
     Value address = nativeArgument(routineContext, argCount, 0);
 
-    if (!isAddressValue(address)) {
+    if (!(isAddressValue(address) || isUint32Pointer(address))) {
         runtimeError(routineContext, "Expected an address or pointer.");
         return false;
     }

--- a/cyarg/object.c
+++ b/cyarg/object.c
@@ -239,8 +239,6 @@ bool isAddressValue(Value val) {
         return i->isLiteral;
     } else if (IS_ADDRESS(val)) {
         return true;
-    } else if (IS_POINTER(val)) {
-        return true;
     } else {
         return false;
     }

--- a/cyarg/vm.c
+++ b/cyarg/vm.c
@@ -1164,7 +1164,7 @@ InterpretResult run(ObjRoutine* routine) {
                 Value assignment = peek(routine, 1);
                 Value assignment_type = concrete_typeof(assignment);
                 tempRootPush(assignment_type);
-                if (!isAddressValue(location) && !isUint32Pointer(location)) {
+                if (!(isAddressValue(location) || isUint32Pointer(location))) {
                     tempRootPop();
                     runtimeError(routine, "Location must be a pointer to an uint32 or address.");
                     return INTERPRET_RUNTIME_ERROR;

--- a/test/yarg-expect/place/offset.ya
+++ b/test/yarg-expect/place/offset.ya
@@ -24,7 +24,7 @@ place struct {
     uint32 flags2;
     } @xc0000000 registers2;
 peek(registers2.ctrl);     // expect: peek(0xc0000010) -> a5a5a5
-peek(registers2.flags);    // expect: peek(0xc0000020) -> a5a5a5
+peek(registers2.flags[0]); // expect: peek(0xc0000020) -> a5a5a5
 peek(registers2.begin);    // expect: peek(0xc0000000) -> a5a5a5
 peek(registers2.ctrl2);    // expect: peek(0xc0000014) -> a5a5a5
 peek(registers2.flags2);   // expect: peek(0xc0000028) -> a5a5a5


### PR DESCRIPTION
peek & poke were not correctly guarding for addresses (assumed to be of uint32 objects), or typed uint32 pointers.