### PR TITLE
Add o1heap

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "hostyarg/littlefs"]
 	path = external/littlefs
 	url = https://github.com/littlefs-project/littlefs
+[submodule "external/o1heap"]
+	path = external/o1heap
+	url = https://github.com/pavel-kirienko/o1heap

--- a/LICENSE_NOTICES
+++ b/LICENSE_NOTICES
@@ -86,3 +86,26 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+-- external/o1heap/
+MIT License
+
+Copyright (c) 2020 Pavel Kirienko
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/cyarg/CMakeLists.txt
+++ b/cyarg/CMakeLists.txt
@@ -115,6 +115,8 @@ add_executable(cyarg
     pack_load.c
     pack_format.h
     pack.h
+    ../external/o1heap/o1heap/o1heap.c
+    ../external/o1heap/o1heap/o1heap.h
     )
 
 if (CYARG_HOSTING STREQUAL "HOSTED")

--- a/cyarg/compiler.c
+++ b/cyarg/compiler.c
@@ -527,14 +527,15 @@ static void generateExprCollectionInit(ObjExprCollectionInitializer* collection)
             ObjExprPair* pair = (ObjExprPair*)item_or_pair;
             generateExpr(pair->a);
             generateExpr(pair->b);
+            emitByte(OP_SET_ELEMENT);
         } else {
             ObjExpr* element = (ObjExpr*)newExprNumberFromCint(i);
-        tempRootPush(OBJ_VAL(element));
+            tempRootPush(OBJ_VAL(element));
             generateExpr(element);
-        generateExpr((ObjExpr*)item_or_pair);
+            generateExpr((ObjExpr*)item_or_pair);
+            emitByte(OP_SET_ELEMENT);
+            tempRootPop();
         }
-        emitByte(OP_SET_ELEMENT);
-        tempRootPop();
     }
 }
 

--- a/cyarg/memory.c
+++ b/cyarg/memory.c
@@ -1,5 +1,7 @@
 #include <stdlib.h>
 #include <stdio.h>
+#include <stdalign.h>
+#include <assert.h>
 
 #include "compiler.h"
 #include "memory.h"
@@ -10,11 +12,28 @@
 #include "sync_group.h"
 #include "platform_hal.h"
 
+#include "../external/o1heap/o1heap/o1heap.h"
+
 #ifdef DEBUG_LOG_GC
 #include "debug.h"
 #endif
 
 #define GC_HEAP_GROW_FACTOR 2
+
+void init_heap_instance(O1HeapInstance** instance) {
+
+#if defined(CYARG_SELF_HOSTED)
+    static alignas(O1HEAP_ALIGNMENT)uint8_t heapArena[190 * 1024];
+#else
+    static alignas(O1HEAP_ALIGNMENT)uint8_t heapArena[10000 * 1024];
+#endif
+
+    *instance = o1heapInit(heapArena, sizeof(heapArena));
+    if (*instance == NULL) {
+        PRINTERR("Failed to initialize heap instance.\n");
+        exit(1);
+    }
+}
 
 // can only be called during gc, so the heap critical section is already held.
 void* gc_free(void* pointer, size_t oldSize, size_t newSize) {
@@ -24,7 +43,7 @@ void* gc_free(void* pointer, size_t oldSize, size_t newSize) {
     }
     vm.bytesAllocated += newSize - oldSize;
 
-    free(pointer);
+    o1heapFree(vm.heap_instance, pointer);
     return NULL;
 }
 
@@ -43,12 +62,12 @@ void* reallocate(void* pointer, size_t oldSize, size_t newSize) {
     }
 
     if (newSize == 0) {
-        free(pointer);
+        o1heapFree(vm.heap_instance, pointer);
         platform_critical_section_exit(&vm.heap);
         return NULL;
     }
 
-    void* result = realloc(pointer, newSize);
+    void* result = o1heapReallocate(vm.heap_instance, pointer, newSize);
     if (result == NULL) {
         PRINTERR("help! no memory.");
         exit(1);
@@ -93,7 +112,7 @@ void markObject(Obj* object) {
 
     if (vm.grayCapacity < vm.grayCount + 1) {
         vm.grayCapacity = GROW_CAPACITY(vm.grayCapacity);
-        vm.grayStack = (Obj**)realloc(vm.grayStack, sizeof(Obj*) * vm.grayCapacity);
+        vm.grayStack = (Obj**)o1heapReallocate(vm.heap_instance, vm.grayStack, sizeof(Obj*) * vm.grayCapacity);
 
         if (vm.grayStack == NULL) exit(1);
     }
@@ -652,6 +671,8 @@ void collectGarbage() {
     size_t before = vm.bytesAllocated;
 #endif
 
+    assert(o1heapDoInvariantsHold(vm.heap_instance));
+
     markRoots();
     traceReferences();
     tableRemoveWhite(&vm.strings);
@@ -677,7 +698,7 @@ void freeObjects() {
         object = next;
     }
 
-    free(vm.grayStack);
+    o1heapFree(vm.heap_instance, vm.grayStack);
 }
 
 void printObjects() {

--- a/cyarg/memory.h
+++ b/cyarg/memory.h
@@ -4,6 +4,10 @@
 #include "common.h"
 #include "object.h"
 
+typedef struct O1HeapInstance O1HeapInstance;
+
+void init_heap_instance(O1HeapInstance** instance);
+
 #define TEMP_ROOTS_MAX 8
 #define FIRST_GC_AT 50 * 1024
 #define ALWAYS_GC_ABOVE 100 * 1024

--- a/cyarg/platform_hal.c
+++ b/cyarg/platform_hal.c
@@ -82,7 +82,7 @@ void platform_critical_section_enter_blocking(platform_critical_section* cs) {
 #if defined(CYARG_PICO_SDK_SYNC)
     critical_section_enter_blocking(cs);
 #elif defined(CYARG_PTHREADS_SYNC)
-    // currently using nop pthread mutex for critical section
+    pthread_mutex_lock(cs);
 #else
     #error "No platform critical section implementation defined."
 #endif
@@ -93,7 +93,7 @@ void platform_critical_section_exit(platform_critical_section* cs) {
 #if defined(CYARG_PICO_SDK_SYNC)
     critical_section_exit(cs);
 #elif defined(CYARG_PTHREADS_SYNC)
-    // currently using nop pthread mutex for critical section
+    pthread_mutex_unlock(cs);
 #else
     #error "No platform critical section implementation defined."
 #endif

--- a/cyarg/vm.c
+++ b/cyarg/vm.c
@@ -138,6 +138,8 @@ void initVMMemory() {
 
     platform_critical_section_init(&vm.heap);
     platform_critical_section_init(&vm.env);
+
+    init_heap_instance(&vm.heap_instance);
 }
 
 void initVMRuntime() {

--- a/cyarg/vm.h
+++ b/cyarg/vm.h
@@ -30,6 +30,7 @@ typedef struct {
     ObjString* libraryPath;
 
     platform_critical_section heap;
+    O1HeapInstance* heap_instance;
 
     Value tempRoots[TEMP_ROOTS_MAX];
     Value* tempRootsTop;


### PR DESCRIPTION
trial integration of o1heap

Fixes two bugs: some sync primitives were NOP on host and an incorrect usage of tempRootStack in map[] initialisation.