### PR TITLE
Rename mutexes to vm_mutex

### DIFF
--- a/cyarg/CMakeLists.txt
+++ b/cyarg/CMakeLists.txt
@@ -105,8 +105,8 @@ add_executable(cyarg
     channel.c
     yargtype.h
     yargtype.c
-    platform_hal.h
-    platform_hal.c
+    vm_mutex.h
+    vm_mutex.c
     sync_group.h
     sync_group.c
     fs/fs.h

--- a/cyarg/channel.c
+++ b/cyarg/channel.c
@@ -6,7 +6,7 @@
 #endif
 
 #include "common.h"
-#include "platform_hal.h"
+#include "vm_mutex.h"
 
 #include "channel.h"
 #include "memory.h"

--- a/cyarg/channel.c
+++ b/cyarg/channel.c
@@ -19,8 +19,8 @@ typedef struct ObjChannelContainer {
     Obj obj;
     bool overflow;
     size_t writeCursor;
-    platform_critical_section lock;
-    platform_critical_section* lock_access;
+    vm_mutex lock;
+    vm_mutex* lock_access;
 #ifdef CYARG_PTHREADS_SYNC
     sem_t* access;
 #endif
@@ -41,7 +41,7 @@ ObjChannelContainer* newChannel(ObjRoutine* routine, size_t capacity) {
     for (int i = 0; i < capacity; i++) {
         channel->buffer[i] = NIL_VAL;
     }
-    platform_critical_section_init(&channel->lock);
+    vm_mutex_init(&channel->lock);
     channel->lock_access = &channel->lock;
 #ifdef CYARG_PTHREADS_SYNC
     channel->access = sem_open("/semaphore", O_CREAT, S_IRUSR | S_IWUSR, 0);
@@ -56,7 +56,7 @@ ObjChannelContainer* newChannel(ObjRoutine* routine, size_t capacity) {
 
 void freeChannelObject(Obj* object) {
     ObjChannelContainer* channel = (ObjChannelContainer*)object;
-    platform_critical_section_deinit(&channel->lock);
+    vm_mutex_deinit(&channel->lock);
 #ifdef CYARG_PTHREADS_SYNC    
     sem_close(channel->access);
 #endif
@@ -73,11 +73,11 @@ size_t readCursor(ObjChannelContainer* channel) {
 }
 
 static void channelMutexEnter(ObjChannelContainer* channel) {
-    platform_critical_section_enter_blocking(channel->lock_access);
+    vm_mutex_enter_blocking(channel->lock_access);
 }
 
 static void channelMutexLeave(ObjChannelContainer* channel) {
-    platform_critical_section_exit(channel->lock_access);
+    vm_mutex_exit(channel->lock_access);
 }
  
 void markChannel(ObjChannelContainer* channel) {
@@ -191,11 +191,11 @@ Value peekChannel(ObjChannelContainer* channel) {
 }
 
 void joinSyncGroup(ObjChannelContainer* channel, ObjSyncGroup* group) {
-    platform_critical_section_deinit(&channel->lock);
+    vm_mutex_deinit(&channel->lock);
     channel->lock_access = getSyncGroupLock(group);
 }
 
 void leaveSyncGroup(ObjChannelContainer* channel, ObjSyncGroup* group) {
-    platform_critical_section_init(&channel->lock);
+    vm_mutex_init(&channel->lock);
     channel->lock_access = &channel->lock;
 }

--- a/cyarg/main.c
+++ b/cyarg/main.c
@@ -10,7 +10,7 @@
 #endif
 
 #include "common.h"
-#include "platform_hal.h"
+#include "vm_mutex.h"
 #include "vm.h"
 #ifdef CYARG_FEATURE_HOSTED_REPL
 #include "hosted.h"

--- a/cyarg/main.c
+++ b/cyarg/main.c
@@ -1,4 +1,8 @@
 #include <stdlib.h>
+#ifdef CYARG_PICO_STDLIB
+#include <pico/stdlib.h>
+#endif
+
 #ifdef CYARG_FEATURE_HOSTED_REPL
 #include <string.h>
 #include <stdio.h>
@@ -49,7 +53,9 @@ const char* getArgument(int argc, const char* argv[], const char* name) {
 
 #if defined(CYARG_FEATURE_SELF_HOSTED_REPL)
 int main() {
-    platform_hal_init();
+#ifdef CYARG_PICO_STDLIB
+    stdio_init_all();
+#endif
 
     initVMMemory();
     initVMRuntime();
@@ -65,7 +71,9 @@ int main() {
 }
 #elif defined(CYARG_FEATURE_HOSTED_REPL)
 int main(int argc, const char* argv[]) {
-    platform_hal_init();
+#ifdef CYARG_PICO_STDLIB
+    stdio_init_all();
+#endif
 
     if (argv[1] && strcmp(argv[1], "--help") == 0) {
         usageMessage(stdout);

--- a/cyarg/memory.c
+++ b/cyarg/memory.c
@@ -10,7 +10,7 @@
 #include "ast.h"
 #include "channel.h"
 #include "sync_group.h"
-#include "platform_hal.h"
+#include "vm_mutex.h"
 
 #include "../external/o1heap/o1heap/o1heap.h"
 

--- a/cyarg/memory.c
+++ b/cyarg/memory.c
@@ -48,7 +48,7 @@ void* gc_free(void* pointer, size_t oldSize, size_t newSize) {
 }
 
 void* reallocate(void* pointer, size_t oldSize, size_t newSize) {
-    platform_critical_section_enter_blocking(&vm.heap);
+    vm_mutex_enter_blocking(&vm.heap);
 
     vm.bytesAllocated += newSize - oldSize;
     if (newSize > oldSize) {
@@ -63,7 +63,7 @@ void* reallocate(void* pointer, size_t oldSize, size_t newSize) {
 
     if (newSize == 0) {
         o1heapFree(vm.heap_instance, pointer);
-        platform_critical_section_exit(&vm.heap);
+        vm_mutex_exit(&vm.heap);
         return NULL;
     }
 
@@ -72,13 +72,13 @@ void* reallocate(void* pointer, size_t oldSize, size_t newSize) {
         PRINTERR("help! no memory.");
         exit(1);
     }
-    platform_critical_section_exit(&vm.heap);
+    vm_mutex_exit(&vm.heap);
     return result;
 }
 
 void tempRootPush(Value value) {
 
-    platform_critical_section_enter_blocking(&vm.heap);
+    vm_mutex_enter_blocking(&vm.heap);
 
     *vm.tempRootsTop = value;
     vm.tempRootsTop++;
@@ -87,14 +87,14 @@ void tempRootPush(Value value) {
         fatalVMError("Allocation Stash Max Exeeded.");
     }
 
-    platform_critical_section_exit(&vm.heap);
+    vm_mutex_exit(&vm.heap);
 }
 
 Value tempRootPop() {
-    platform_critical_section_enter_blocking(&vm.heap);
+    vm_mutex_enter_blocking(&vm.heap);
     vm.tempRootsTop--;
     Value result = *vm.tempRootsTop;
-    platform_critical_section_exit(&vm.heap);
+    vm_mutex_exit(&vm.heap);
     return result;
 }
 

--- a/cyarg/object.c
+++ b/cyarg/object.c
@@ -21,12 +21,12 @@ Obj* allocateObject(size_t size, ObjType type) {
     object->type = type;
     object->isMarked = false;
 
-    platform_critical_section_enter_blocking(&vm.heap);
+    vm_mutex_enter_blocking(&vm.heap);
 
     object->next = vm.objects;
     vm.objects = object;
     
-    platform_critical_section_exit(&vm.heap);
+    vm_mutex_exit(&vm.heap);
 
 #ifdef DEBUG_LOG_GC
     PRINTERR("%p allocate %zu for %d\n", (void*)object, size, type);

--- a/cyarg/platform_hal.c
+++ b/cyarg/platform_hal.c
@@ -1,7 +1,4 @@
 #include <stdio.h>
-#ifdef CYARG_PICO_STDLIB
-#include <pico/stdlib.h>
-#endif
 
 #if defined(CYARG_PICO_SDK_SYNC)
 #include <pico/sync.h>
@@ -12,12 +9,6 @@
 #endif
 
 #include "platform_hal.h"
-
-void platform_hal_init() {
-#ifdef CYARG_PICO_STDLIB
-    stdio_init_all();
-#endif
-}
 
 void platform_critical_section_init(platform_critical_section* cs) {
 #if defined(CYARG_PICO_SDK_SYNC)

--- a/cyarg/platform_hal.c
+++ b/cyarg/platform_hal.c
@@ -19,41 +19,6 @@ void platform_hal_init() {
 #endif
 }
 
-void platform_mutex_init(platform_mutex* mutex) {
-#if defined(CYARG_PICO_SDK_SYNC)
-    recursive_mutex_init(mutex);
-#elif defined(CYARG_PTHREADS_SYNC)
-    static pthread_mutexattr_t attr;
-    pthread_mutexattr_init(&attr);
-    pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE);
-    int i = pthread_mutex_init(mutex, &attr); // not recursive
-    if (i != 0)
-	printf("pthread_mutex_init %d\n", i);
-#else
-    #error "No platform mutex implementation defined."
-#endif
-}
-
-void platform_mutex_enter(platform_mutex* mutex) {
-#if defined(CYARG_PICO_SDK_SYNC)
-    recursive_mutex_enter_blocking (mutex);
-#elif defined(CYARG_PTHREADS_SYNC)
-    pthread_mutex_lock(mutex);
-#else
-    #error "No platform mutex implementation defined."
-#endif
-}
-
-void platform_mutex_leave(platform_mutex* mutex) {
-#if defined(CYARG_PICO_SDK_SYNC)
-    recursive_mutex_exit(mutex);
-#elif defined(CYARG_PTHREADS_SYNC)
-    pthread_mutex_unlock(mutex);
-#else
-    #error "No platform mutex implementation defined."
-#endif
-}
-
 void platform_critical_section_init(platform_critical_section* cs) {
 #if defined(CYARG_PICO_SDK_SYNC)
     critical_section_init(cs);

--- a/cyarg/platform_hal.c
+++ b/cyarg/platform_hal.c
@@ -10,7 +10,7 @@
 
 #include "platform_hal.h"
 
-void platform_critical_section_init(platform_critical_section* cs) {
+void vm_mutex_init(vm_mutex* cs) {
 #if defined(CYARG_PICO_SDK_SYNC)
     critical_section_init(cs);
 #elif defined(CYARG_PTHREADS_SYNC)
@@ -24,7 +24,7 @@ void platform_critical_section_init(platform_critical_section* cs) {
 #endif
 }
 
-void platform_critical_section_deinit(platform_critical_section* cs) {
+void vm_mutex_deinit(vm_mutex* cs) {
 #if defined(CYARG_PICO_SDK_SYNC)
     critical_section_deinit(cs);
 #elif defined(CYARG_PTHREADS_SYNC)
@@ -34,7 +34,7 @@ void platform_critical_section_deinit(platform_critical_section* cs) {
 #endif
 }
 
-void platform_critical_section_enter_blocking(platform_critical_section* cs) {
+void vm_mutex_enter_blocking(vm_mutex* cs) {
 #if defined(CYARG_PICO_SDK_SYNC)
     critical_section_enter_blocking(cs);
 #elif defined(CYARG_PTHREADS_SYNC)
@@ -45,7 +45,7 @@ void platform_critical_section_enter_blocking(platform_critical_section* cs) {
 
 }
 
-void platform_critical_section_exit(platform_critical_section* cs) {
+void vm_mutex_exit(vm_mutex* cs) {
 #if defined(CYARG_PICO_SDK_SYNC)
     critical_section_exit(cs);
 #elif defined(CYARG_PTHREADS_SYNC)

--- a/cyarg/platform_hal.h
+++ b/cyarg/platform_hal.h
@@ -3,14 +3,14 @@
 
 #if defined(CYARG_PICO_SDK_SYNC)
 #include <pico/sync.h>
-typedef critical_section_t platform_critical_section;
+typedef critical_section_t vm_mutex;
 #elif defined(CYARG_PTHREADS_SYNC)
 #include <pthread.h>
-typedef pthread_mutex_t platform_critical_section;
+typedef pthread_mutex_t vm_mutex;
 #endif
 
-void platform_critical_section_init(platform_critical_section* cs);
-void platform_critical_section_deinit(platform_critical_section* cs);
-void platform_critical_section_enter_blocking(platform_critical_section* cs);
-void platform_critical_section_exit(platform_critical_section* cs);
+void vm_mutex_init(vm_mutex* cs);
+void vm_mutex_deinit(vm_mutex* cs);
+void vm_mutex_enter_blocking(vm_mutex* cs);
+void vm_mutex_exit(vm_mutex* cs);
 #endif

--- a/cyarg/platform_hal.h
+++ b/cyarg/platform_hal.h
@@ -1,8 +1,6 @@
 #ifndef cyarg_platform_hal_h
 #define cyarg_platform_hal_h
 
-void platform_hal_init();
-
 #if defined(CYARG_PICO_SDK_SYNC)
 #include <pico/sync.h>
 typedef critical_section_t platform_critical_section;

--- a/cyarg/platform_hal.h
+++ b/cyarg/platform_hal.h
@@ -5,17 +5,11 @@ void platform_hal_init();
 
 #if defined(CYARG_PICO_SDK_SYNC)
 #include <pico/sync.h>
-typedef recursive_mutex_t platform_mutex;
 typedef critical_section_t platform_critical_section;
 #elif defined(CYARG_PTHREADS_SYNC)
 #include <pthread.h>
-typedef pthread_mutex_t platform_mutex;
 typedef pthread_mutex_t platform_critical_section;
 #endif
-
-void platform_mutex_init(platform_mutex* mutex);
-void platform_mutex_enter(platform_mutex* mutex);
-void platform_mutex_leave(platform_mutex* mutex);
 
 void platform_critical_section_init(platform_critical_section* cs);
 void platform_critical_section_deinit(platform_critical_section* cs);

--- a/cyarg/sync_group.c
+++ b/cyarg/sync_group.c
@@ -12,7 +12,7 @@
 
 typedef struct ObjSyncGroup {
     Obj obj;
-    platform_critical_section group_lock;
+    vm_mutex group_lock;
     ObjPackedUniformArray* channel_array;
     ObjPackedUniformArray* result_array;
 } ObjSyncGroup;
@@ -20,7 +20,7 @@ typedef struct ObjSyncGroup {
 ObjSyncGroup* newSyncGroup(ObjRoutine* routine, ObjPackedUniformArray* items) {
     ObjSyncGroup* group = ALLOCATE_OBJ(ObjSyncGroup, OBJ_SYNCGROUP);
     push(routine, OBJ_VAL(group));
-    platform_critical_section_init(&group->group_lock);
+    vm_mutex_init(&group->group_lock);
     group->channel_array = items;
     ObjConcreteYargTypeArray* t = (ObjConcreteYargTypeArray*)newYargArrayTypeFromType(NIL_VAL);
     push(routine, OBJ_VAL(t));
@@ -33,7 +33,7 @@ ObjSyncGroup* newSyncGroup(ObjRoutine* routine, ObjPackedUniformArray* items) {
 
 void freeSyncGroup(Obj* obj) {
     ObjSyncGroup* group = (ObjSyncGroup*)obj;
-    platform_critical_section_deinit(&group->group_lock);
+    vm_mutex_deinit(&group->group_lock);
     FREE(ObjSyncGroup, obj);
 }
 
@@ -60,7 +60,7 @@ Value receiveSyncGroup(ObjSyncGroup* group) {
     bool wait_complete = false;
     while (!wait_complete && num_channels > 0) {
         wait_complete = false;
-        platform_critical_section_enter_blocking(&group->group_lock);
+        vm_mutex_enter_blocking(&group->group_lock);
         for (size_t i = 0; i < num_channels; i++) {
             PackedValue channel_cursor = arrayElement(group->channel_array->store, i);
             Value channelVal = unpackValue(channel_cursor);
@@ -75,11 +75,11 @@ Value receiveSyncGroup(ObjSyncGroup* group) {
             PackedValue trg = arrayElement(group->result_array->store, i);
             assignToPackedValue(trg, data);
         }
-        platform_critical_section_exit(&group->group_lock);
+        vm_mutex_exit(&group->group_lock);
     }
     return OBJ_VAL(group->result_array);
 }
 
-platform_critical_section* getSyncGroupLock(ObjSyncGroup* group) {
+vm_mutex* getSyncGroupLock(ObjSyncGroup* group) {
     return &group->group_lock;
 }

--- a/cyarg/sync_group.h
+++ b/cyarg/sync_group.h
@@ -4,7 +4,7 @@
 #include <stdio.h>
 #include "value.h"
 #include "object.h"
-#include "platform_hal.h"
+#include "vm_mutex.h"
 
 typedef struct ObjSyncGroup ObjSyncGroup;
 

--- a/cyarg/sync_group.h
+++ b/cyarg/sync_group.h
@@ -17,6 +17,6 @@ ObjString* syncGroupToString(ObjSyncGroup* group);
 
 Value receiveSyncGroup(ObjSyncGroup* group);
 
-platform_critical_section* getSyncGroupLock(ObjSyncGroup* group);
+vm_mutex* getSyncGroupLock(ObjSyncGroup* group);
 
 #endif

--- a/cyarg/vm.c
+++ b/cyarg/vm.c
@@ -136,8 +136,8 @@ void initVMMemory() {
 
     vm.nextGC = FIRST_GC_AT;
 
-    platform_critical_section_init(&vm.heap);
-    platform_critical_section_init(&vm.env);
+    vm_mutex_init(&vm.heap);
+    vm_mutex_init(&vm.env);
 
     init_heap_instance(&vm.heap_instance);
 }
@@ -794,28 +794,28 @@ InterpretResult run(ObjRoutine* routine) {
                 break;
             }
             case OP_GET_GLOBAL: {
-                platform_critical_section_enter_blocking(&vm.env);
+                vm_mutex_enter_blocking(&vm.env);
                 ObjString* name = READ_STRING();
                 ValueCell cell;
                 if (!tableCellGet(&vm.globals, name, &cell)) {
                     runtimeError(routine, "Undefined variable (OP_GET_GLOBAL) '%s'.", name->chars);
-                    platform_critical_section_exit(&vm.env);
+                    vm_mutex_exit(&vm.env);
                     return INTERPRET_RUNTIME_ERROR;
                 }
                 push(routine, cell.value);
-                platform_critical_section_exit(&vm.env);
+                vm_mutex_exit(&vm.env);
                 break;
             }
             case OP_DEFINE_GLOBAL: {
-                platform_critical_section_enter_blocking(&vm.env);
+                vm_mutex_enter_blocking(&vm.env);
                 ObjString* name = READ_STRING();
                 tableCellSet(&vm.globals, name, *peekCell(routine, 0));
                 pop(routine);
-                platform_critical_section_exit(&vm.env);
+                vm_mutex_exit(&vm.env);
                 break;
             }
             case OP_SET_GLOBAL: {
-                platform_critical_section_enter_blocking(&vm.env);
+                vm_mutex_enter_blocking(&vm.env);
                 ObjString* name = READ_STRING();
                 ValueCell* lhs = NULL;
                 if (tableCellGetPlace(&vm.globals, name, &lhs)) {
@@ -824,15 +824,15 @@ InterpretResult run(ObjRoutine* routine) {
 
                     if (!assignToValueCellTarget(lhsTrg, rhs->value)) {
                         runtimeError(routine, "Cannot set global variable to incompatible type.");
-                        platform_critical_section_exit(&vm.env);
+                        vm_mutex_exit(&vm.env);
                         return INTERPRET_RUNTIME_ERROR;
                     }
                 } else {
                     runtimeError(routine, "Undefined variable (OP_SET_GLOBAL) '%s'.", name->chars);
-                    platform_critical_section_exit(&vm.env);
+                    vm_mutex_exit(&vm.env);
                     return INTERPRET_RUNTIME_ERROR;
                 }
-                platform_critical_section_exit(&vm.env);
+                vm_mutex_exit(&vm.env);
                 break;
             }
             case OP_INITIALISE: {

--- a/cyarg/vm.h
+++ b/cyarg/vm.h
@@ -8,7 +8,7 @@
 
 #include "memory.h"
 #include "routine.h"
-#include "platform_hal.h"
+#include "vm_mutex.h"
 
 #define MAX_PINNED_ROUTINES 10
 

--- a/cyarg/vm.h
+++ b/cyarg/vm.h
@@ -22,14 +22,14 @@ typedef struct {
     ObjRoutine* pinnedRoutines[MAX_PINNED_ROUTINES];
     PinnedRoutineHandler pinnedRoutineHandlers[MAX_PINNED_ROUTINES];
     
-    platform_critical_section env;
+    vm_mutex env;
     
     ValueCellTable globals;
     ValueTable strings;
     ObjString* initString;
     ObjString* libraryPath;
 
-    platform_critical_section heap;
+    vm_mutex heap;
     O1HeapInstance* heap_instance;
 
     Value tempRoots[TEMP_ROOTS_MAX];

--- a/cyarg/vm_mutex.c
+++ b/cyarg/vm_mutex.c
@@ -16,7 +16,7 @@ void vm_mutex_init(vm_mutex* cs) {
 #elif defined(CYARG_PTHREADS_SYNC)
     pthread_mutexattr_t attr;
     pthread_mutexattr_init(&attr);
-    pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE);
+    pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_NORMAL);
     pthread_mutex_init(cs, &attr);
     pthread_mutexattr_destroy(&attr);
 #else

--- a/cyarg/vm_mutex.c
+++ b/cyarg/vm_mutex.c
@@ -8,7 +8,7 @@
 #error "No platform mutex implementation defined."
 #endif
 
-#include "platform_hal.h"
+#include "vm_mutex.h"
 
 void vm_mutex_init(vm_mutex* cs) {
 #if defined(CYARG_PICO_SDK_SYNC)

--- a/cyarg/vm_mutex.h
+++ b/cyarg/vm_mutex.h
@@ -1,6 +1,19 @@
 #ifndef cyarg_vm_mutex_h
 #define cyarg_vm_mutex_h
 
+/* vm_mutex
+ * 
+ * In order to support Yarg's concurrency model, we need a mutex.
+ * On host, it should be functional between threads in the VM process.
+ * On target, it should be functional between normal and interrupt contexts.
+ * 
+ * Currently, the mutex is not recursively enterable, in order to use the 
+ * Pico SDK's critical_section to implement it on target.
+ * 
+ * Host Implementation: pthread_mutex
+ * Pico Implementation: Pico SDK critical_section
+ */
+
 #if defined(CYARG_PICO_SDK_SYNC)
 #include <pico/sync.h>
 typedef critical_section_t vm_mutex;

--- a/cyarg/vm_mutex.h
+++ b/cyarg/vm_mutex.h
@@ -1,5 +1,5 @@
-#ifndef cyarg_platform_hal_h
-#define cyarg_platform_hal_h
+#ifndef cyarg_vm_mutex_h
+#define cyarg_vm_mutex_h
 
 #if defined(CYARG_PICO_SDK_SYNC)
 #include <pico/sync.h>


### PR DESCRIPTION
rename withdraw platform_hal, and provide vm_mutex as a substitute.

Withdraw platform_hal_init, as it didn't do much.